### PR TITLE
Refactor magic numbers

### DIFF
--- a/cmd/ip-fetcher/abuseipdb.go
+++ b/cmd/ip-fetcher/abuseipdb.go
@@ -9,6 +9,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	defaultConfidence = 75
+	defaultLimit      = 1000
+)
+
 func abuseipdbCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "abuseipdb",
@@ -26,12 +31,16 @@ func abuseipdbCmd() *cli.Command {
 				Usage: "api key", Aliases: []string{"k"}, Required: true,
 			},
 			&cli.IntFlag{
-				Name:  "confidence",
-				Usage: "minimum confidence percentage score to return", Value: 75, Aliases: []string{"c"},
+				Name:    "confidence",
+				Usage:   "minimum confidence percentage score to return",
+				Value:   defaultConfidence,
+				Aliases: []string{"c"},
 			},
 			&cli.Int64Flag{
-				Name:  "limit",
-				Usage: "maximum number of results to return", Value: 1000, Aliases: []string{"l"},
+				Name:    "limit",
+				Usage:   "maximum number of results to return",
+				Value:   defaultLimit,
+				Aliases: []string{"l"},
 			},
 			&cli.StringFlag{
 				Name:  "path",

--- a/cmd/ip-fetcher/akamai.go
+++ b/cmd/ip-fetcher/akamai.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -52,7 +53,7 @@ func akamaiCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/akamai/testdata/prefixes.txt")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/aws.go
+++ b/cmd/ip-fetcher/aws.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -55,7 +56,7 @@ func awsCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/aws/testdata/ip-ranges.json")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/azure.go
+++ b/cmd/ip-fetcher/azure.go
@@ -59,7 +59,7 @@ func azureCmd() *cli.Command {
 				// u, _ := url.Parse(azure.InitialURL)
 				// gock.New(azure.InitialURL).
 				// 	Get(u.Path).
-				// 	Reply(200).
+				// 	Reply(http.StatusOK).
 				// 	File(testAzureInitialFilePath)
 
 				uDownload, _ := url.Parse(testMockAzureDownloadURL)

--- a/cmd/ip-fetcher/bingbot.go
+++ b/cmd/ip-fetcher/bingbot.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/jonhadfield/ip-fetcher/providers/bingbot"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -53,7 +54,7 @@ func bingbotCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/bingbot/testdata/bingbot.json")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/cloudflare.go
+++ b/cmd/ip-fetcher/cloudflare.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -76,13 +77,13 @@ func cloudflareCmd() *cli.Command {
 				exTimeStamp := "Tue, 13 Dec 2022 06:50:50 GMT"
 				gock.New(url4Base).
 					Get(u4.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					AddHeader("Last-Modified", exTimeStamp).
 					File("../../providers/cloudflare/testdata/ips-v4")
 				url6Base := fmt.Sprintf("%s://%s", u6.Scheme, u6.Host)
 				gock.New(url6Base).
 					Get(u6.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					AddHeader("Last-Modified", exTimeStamp).
 					File("../../providers/cloudflare/testdata/ips-v6")
 

--- a/cmd/ip-fetcher/digitalocean.go
+++ b/cmd/ip-fetcher/digitalocean.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -48,7 +49,7 @@ func digitaloceanCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/digitalocean/testdata/google.csv")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/fastly.go
+++ b/cmd/ip-fetcher/fastly.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"slices"
@@ -62,7 +63,7 @@ func fastlyCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/fastly/testdata/fastly.json")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/gcp.go
+++ b/cmd/ip-fetcher/gcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -60,7 +61,7 @@ func gcpCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/gcp/testdata/cloud.json")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/github.go
+++ b/cmd/ip-fetcher/github.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func githubCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/github/testdata/meta.json")
 				gock.InterceptClient(gh.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/google.go
+++ b/cmd/ip-fetcher/google.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -53,7 +54,7 @@ func googleCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/google/testdata/goog.json")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/googlebot.go
+++ b/cmd/ip-fetcher/googlebot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func googlebotCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/googlebot/testdata/googlebot.json")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/googlesc.go
+++ b/cmd/ip-fetcher/googlesc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func googlescCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/googlesc/testdata/special-crawlers.json")
 				gock.InterceptClient(g.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/googleutf.go
+++ b/cmd/ip-fetcher/googleutf.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func googleutfCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/googleutf/testdata/user-triggered-fetchers.json")
 				gock.InterceptClient(g.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/hetzner.go
+++ b/cmd/ip-fetcher/hetzner.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -55,7 +56,7 @@ func hetznerCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/hetzner/testdata/prefixes.json")
 				gock.InterceptClient(h.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/icloudpr.go
+++ b/cmd/ip-fetcher/icloudpr.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/jonhadfield/ip-fetcher/providers/icloudpr"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -56,7 +57,7 @@ func iCloudPRCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/icloudpr/testdata/egress-ip-ranges.csv")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/linode.go
+++ b/cmd/ip-fetcher/linode.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -56,7 +57,7 @@ func linodeCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/linode/testdata/prefixes.csv")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/oci.go
+++ b/cmd/ip-fetcher/oci.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -57,7 +58,7 @@ func ociCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/oci/testdata/public_ip_ranges.json")
 				gock.InterceptClient(a.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/ovh.go
+++ b/cmd/ip-fetcher/ovh.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func ovhCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/ovh/testdata/prefixes.txt")
 				gock.InterceptClient(o.Client.HTTPClient)
 			}

--- a/cmd/ip-fetcher/url.go
+++ b/cmd/ip-fetcher/url.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -69,7 +70,7 @@ func urlCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/url/testdata/ip-file-1.txt")
 				gock.InterceptClient(h.HttpClient.HTTPClient)
 			}

--- a/cmd/ip-fetcher/zscaler.go
+++ b/cmd/ip-fetcher/zscaler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -52,7 +53,7 @@ func zscalerCmd() *cli.Command {
 				u, _ := url.Parse(urlBase)
 				gock.New(urlBase).
 					Get(u.Path).
-					Reply(200).
+					Reply(http.StatusOK).
 					File("../../providers/zscaler/testdata/prefixes.txt")
 				gock.InterceptClient(z.Client.HTTPClient)
 			}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -33,13 +33,19 @@ func Resolve(name string) (ip netip.Addr, err error) {
 	return netip.ParseAddr(i.String())
 }
 
+const (
+	defaultRetryMax     = 2
+	defaultRetryWaitMin = 2 * time.Second
+	defaultRetryWaitMax = 5 * time.Second
+)
+
 func NewHTTPClient() *retryablehttp.Client {
 	rc := &http.Client{Transport: &http.Transport{}}
 	c := retryablehttp.NewClient()
 	c.HTTPClient = rc
-	c.RetryMax = 2
-	c.RetryWaitMin = 2 * time.Second
-	c.RetryWaitMax = 5 * time.Second
+	c.RetryMax = defaultRetryMax
+	c.RetryWaitMin = defaultRetryWaitMin
+	c.RetryWaitMax = defaultRetryWaitMax
 
 	return c
 }

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -68,7 +68,7 @@ func TestRequestContentDispositionFileName(t *testing.T) {
 		MatchParams(map[string]string{
 			"qsparam": "qsvalue",
 		}).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", fmt.Sprintf("attachment; filename=%s", fileName))
 
 	gock.New(urlBase).
@@ -76,7 +76,7 @@ func TestRequestContentDispositionFileName(t *testing.T) {
 		MatchParams(map[string]string{
 			"qsparam": "qsvalue",
 		}).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "")
 
 	c := NewHTTPClient()
@@ -180,7 +180,7 @@ func TestDownloadFileWithMissingDir(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/mytextfile.txt").
 		SetHeader("hello", "World")
 
@@ -203,7 +203,7 @@ func TestDownloadFileWithDirSpecified(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/mytextfile.txt").
 		SetHeader("hello", "World")
 
@@ -226,7 +226,7 @@ func TestDownloadFileWithFilePathSpecified(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/mytextfile.txt").
 		SetHeader("hello", "World")
 
@@ -249,7 +249,7 @@ func TestHTTPGet(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/mytextfile.txt").
 		SetHeader("hello", "World")
 
@@ -259,7 +259,7 @@ func TestHTTPGet(t *testing.T) {
 
 	b, headers, status, err := Request(c, testUrl, http.MethodGet, nil, nil, 2*time.Second)
 	require.NoError(t, err)
-	require.Equal(t, 200, status)
+	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "hello world", string(b))
 	require.Equal(t, "World", headers.Get("hello"))
 }

--- a/providers/abuseipdb/abuseipdb.go
+++ b/providers/abuseipdb/abuseipdb.go
@@ -71,7 +71,7 @@ func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, err
 		return false, fmt.Errorf("exceeded number of allowed blacklist downloads in last 24 hours")
 	}
 
-	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented) {
+	if resp.StatusCode == 0 || (resp.StatusCode >= http.StatusInternalServerError && resp.StatusCode != http.StatusNotImplemented) {
 		return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
 	}
 
@@ -140,7 +140,7 @@ func (a *AbuseIPDB) FetchData() (data []byte, headers http.Header, status int, e
 		return
 	}
 
-	if statusCode >= 400 && statusCode < 500 {
+	if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
 		err = parseAPIErrorResponse(blackList)
 	}
 

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -86,7 +86,7 @@ func (a *AWS) FetchETag() (etag string, err error) {
 		return
 	}
 
-	if statusCode != 200 {
+	if statusCode != http.StatusOK {
 		// err = fmt.Errorf("%s - request for aws etag resulted in status code: %d", funcName, statusCode)
 		return
 	}

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -49,7 +49,7 @@ func (a *DigitalOcean) FetchData() (data []byte, headers http.Header, status int
 	}
 
 	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, 5*time.Second)
-	if status >= 400 {
+	if status >= http.StatusBadRequest {
 		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
 	}
 

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -90,7 +90,7 @@ func (a *ICloudPrivateRelay) FetchData() (data []byte, headers http.Header, stat
 	}
 
 	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, 5*time.Second)
-	if status >= 400 {
+	if status >= http.StatusBadRequest {
 		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
 	}
 

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -90,7 +90,7 @@ func (a *Linode) FetchData() (data []byte, headers http.Header, status int, err 
 	}
 
 	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, 5*time.Second)
-	if status >= 400 {
+	if status >= http.StatusBadRequest {
 		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
 	}
 

--- a/providers/url/url.go
+++ b/providers/url/url.go
@@ -309,7 +309,7 @@ func (c *Client) get(url *url.URL, header http.Header) (result UrlResponse, err 
 		logrus.Debug(err.Error())
 	}
 
-	if !(status >= 200 && status <= 299) {
+	if status < http.StatusOK || status >= http.StatusMultipleChoices {
 		return result, fmt.Errorf("failed to get: %s status: %d", url.String(), status)
 	}
 
@@ -328,7 +328,7 @@ func fetchUrlResponse(client *retryablehttp.Client, url string) (result UrlRespo
 	if err != nil {
 		logrus.Debug(err.Error())
 	}
-	if !(status >= 200 && status <= 299) {
+	if status < http.StatusOK || status >= http.StatusMultipleChoices {
 		return result, fmt.Errorf("failed to fetch: %s status: %d", url, status)
 	}
 


### PR DESCRIPTION
## Summary
- use named constants in HTTP client configuration
- add default constants for AbuseIPDB CLI
- reference status constants instead of raw numbers
- update tests to use constants
- import `net/http` in CLI modules for gock responses

## Testing
- `go vet ./...`
- `go test ./...` *(fails: open testdata/GeoLite2-ASN-CSV_20220617.zip: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683c92a313c883209f80d4ad76b12787