### PR TITLE
Remove named returns and magic numbers

### DIFF
--- a/cmd/ip-fetcher/url.go
+++ b/cmd/ip-fetcher/url.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -81,7 +82,7 @@ func urlCmd() *cli.Command {
 			}
 
 			if len(prefixes) == 0 {
-				return fmt.Errorf("no prefixes found")
+				return errors.New("no prefixes found")
 			}
 
 			if path != "" {

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -24,10 +24,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Resolve(name string) (ip netip.Addr, err error) {
+func Resolve(name string) (netip.Addr, error) {
 	i, err := net.ResolveIPAddr("ip", name)
 	if err != nil {
-		return
+		return netip.Addr{}, err
 	}
 
 	return netip.ParseAddr(i.String())
@@ -37,6 +37,12 @@ const (
 	defaultRetryMax     = 2
 	defaultRetryWaitMin = 2 * time.Second
 	defaultRetryWaitMax = 5 * time.Second
+	// DefaultRequestTimeout is used for HTTP requests unless otherwise specified
+	DefaultRequestTimeout = 10 * time.Second
+	// ShortRequestTimeout is used for short HTTP requests
+	ShortRequestTimeout = 5 * time.Second
+	// LongRequestTimeout is used for lengthy HTTP requests
+	LongRequestTimeout = 30 * time.Second
 )
 
 func NewHTTPClient() *retryablehttp.Client {
@@ -58,18 +64,14 @@ func MaskSecrets(content string, secret []string) string {
 	return content
 }
 
-func Request(c *retryablehttp.Client, url string, method string, inHeaders http.Header, secrets []string, timeout time.Duration) (body []byte, headers http.Header, status int, err error) {
+func Request(c *retryablehttp.Client, url, method string, inHeaders http.Header, secrets []string, timeout time.Duration) ([]byte, http.Header, int, error) {
 	if method == "" {
-		err = fmt.Errorf("HTTP method not specified")
-
-		return
+		return nil, nil, 0, errors.New("HTTP method not specified")
 	}
 
 	request, err := retryablehttp.NewRequest(method, url, nil)
 	if err != nil {
-		err = fmt.Errorf("failed to request %s: %w", MaskSecrets(url, secrets), err)
-
-		return
+		return nil, nil, 0, fmt.Errorf("failed to request %s: %w", MaskSecrets(url, secrets), err)
 	}
 
 	request.Header = inHeaders
@@ -83,35 +85,34 @@ func Request(c *retryablehttp.Client, url string, method string, inHeaders http.
 
 	request = request.WithContext(ctx)
 
-	var resp *http.Response
-
-	resp, err = c.Do(request)
+	resp, err := c.Do(request)
 	if err != nil {
-		return
-	}
-
-	headers = resp.Header
-
-	body, err = GetResponseBody(resp)
-	if err != nil {
-		err = fmt.Errorf("%w", err)
-
-		return
+		return nil, nil, 0, err
 	}
 	defer resp.Body.Close()
 
-	return body, resp.Header, resp.StatusCode, err
+	headers := resp.Header
+
+	body, err := GetResponseBody(resp)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("%w", err)
+	}
+
+	return body, headers, resp.StatusCode, nil
 }
 
 // GetResourceHeaderValue will make an HTTP request and return the value of the specified header
-func GetResourceHeaderValue(client *retryablehttp.Client, url, method, header string, secrets []string) (result string, err error) {
+func GetResourceHeaderValue(client *retryablehttp.Client, url, method, header string, secrets []string) (string, error) {
 	if header == "" {
-		return "", fmt.Errorf("header must not be empty")
+		return "", errors.New("header must not be empty")
 	}
 
-	_, response, _, err := Request(client, url, method, nil, secrets, 30*time.Second)
+	_, response, _, err := Request(client, url, method, nil, secrets, LongRequestTimeout)
+	if err != nil {
+		return "", err
+	}
 
-	return response.Get(header), err
+	return response.Get(header), nil
 }
 
 type pathInfo struct {
@@ -158,7 +159,7 @@ func getPathInfo(p string) (pathInfo, error) {
 
 func DownloadFile(client *retryablehttp.Client, u, path string) (string, error) {
 	if u == "" {
-		return "", fmt.Errorf("url must not be empty")
+		return "", errors.New("url must not be empty")
 	}
 
 	logrus.Debugf("%s | downloading: %s to %s", pflog.GetFunctionName(), u, path)
@@ -178,7 +179,7 @@ func DownloadFile(client *retryablehttp.Client, u, path string) (string, error) 
 	case info.exists || info.parentExists:
 		// path is valid as provided
 	default:
-		return "", fmt.Errorf("parent directory does not exist")
+		return "", errors.New("parent directory does not exist")
 	}
 
 	logrus.Infof("downloading %s to %s", u, path)
@@ -209,14 +210,14 @@ func DownloadFile(client *retryablehttp.Client, u, path string) (string, error) 
 	return path, nil
 }
 
-func RequestContentDispositionFileName(httpClient *retryablehttp.Client, url string, secrets []string) (filename string, err error) {
+func RequestContentDispositionFileName(httpClient *retryablehttp.Client, url string, secrets []string) (string, error) {
 	logrus.Debugf("requesting filename %s", MaskSecrets(url, secrets))
 
 	contentDispHeader, err := GetResourceHeaderValue(
 		httpClient, url, http.MethodHead, "Content-Disposition", secrets,
 	)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	_, params, err := mime.ParseMediaType(contentDispHeader)
@@ -228,35 +229,28 @@ func RequestContentDispositionFileName(httpClient *retryablehttp.Client, url str
 		return "", errors.New("failed to get Content-Disposition header")
 	}
 
-	return params["filename"], err
+	return params["filename"], nil
 }
 
-func GetResponseBody(resp *http.Response) (body []byte, err error) {
+func GetResponseBody(resp *http.Response) ([]byte, error) {
 	var output io.ReadCloser
 
+	var err error
 	switch resp.Header.Get("Content-Encoding") {
 	case "gzip":
 		output, err = gzip.NewReader(resp.Body)
-
 		if err != nil {
-			return
+			return nil, err
 		}
 	default:
 		output = resp.Body
-
-		if err != nil {
-			return
-		}
 	}
 
 	buf := new(bytes.Buffer)
 
-	_, err = buf.ReadFrom(output)
-	if err != nil {
-		return
+	if _, err = buf.ReadFrom(output); err != nil {
+		return nil, err
 	}
 
-	body = buf.Bytes()
-
-	return
+	return buf.Bytes(), nil
 }

--- a/providers/abuseipdb/abuseipdb.go
+++ b/providers/abuseipdb/abuseipdb.go
@@ -68,7 +68,7 @@ func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, err
 	}
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return false, fmt.Errorf("exceeded number of allowed blacklist downloads in last 24 hours")
+		return false, errors.New("exceeded number of allowed blacklist downloads in last 24 hours")
 	}
 
 	if resp.StatusCode == 0 || (resp.StatusCode >= http.StatusInternalServerError && resp.StatusCode != http.StatusNotImplemented) {
@@ -129,7 +129,7 @@ func (a *AbuseIPDB) FetchData() (data []byte, headers http.Header, status int, e
 		reqUrl.RawQuery = q.Encode()
 	}
 
-	blackList, headers, statusCode, err := web.Request(a.Client, reqUrl.String(), http.MethodGet, inHeaders, []string{a.APIKey}, 10*time.Second)
+	blackList, headers, statusCode, err := web.Request(a.Client, reqUrl.String(), http.MethodGet, inHeaders, []string{a.APIKey}, web.DefaultRequestTimeout)
 	if statusCode == 0 && err != nil {
 		return
 	}

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -6,7 +6,6 @@ import (
 	"net/netip"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/jonhadfield/ip-fetcher/internal/pflog"
 	"github.com/sirupsen/logrus"
@@ -60,13 +59,11 @@ func New() AWS {
 	}
 }
 
-func (a *AWS) FetchETag() (etag string, err error) {
+func (a *AWS) FetchETag() (string, error) {
+	var err error
 	// get download url if not specified
 	if a.DownloadURL == "" {
 		a.DownloadURL = DownloadURL
-		if err != nil {
-			return
-		}
 	}
 
 	inHeaders := http.Header{}
@@ -74,91 +71,89 @@ func (a *AWS) FetchETag() (etag string, err error) {
 
 	var reqUrl *url.URL
 	if reqUrl, err = url.Parse(a.DownloadURL); err != nil {
-		return
+		return "", err
 	}
 
 	var outHeaders http.Header
 
 	var statusCode int
 
-	_, outHeaders, statusCode, err = web.Request(a.Client, reqUrl.String(), http.MethodHead, inHeaders, []string{}, 5*time.Second)
+	_, outHeaders, statusCode, err = web.Request(a.Client, reqUrl.String(), http.MethodHead, inHeaders, []string{}, web.ShortRequestTimeout)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	if statusCode != http.StatusOK {
 		// err = fmt.Errorf("%s - request for aws etag resulted in status code: %d", funcName, statusCode)
-		return
+		return "", nil
 	}
 
-	etag = outHeaders.Get("Etag")
+	etag := outHeaders.Get("Etag")
 	if etag != "" && len(etag) > 2 {
 		TrimQuotes(&etag)
 	}
 
-	return etag, err
+	return etag, nil
 }
 
-func (a *AWS) FetchData() (data []byte, headers http.Header, status int, err error) {
+func (a *AWS) FetchData() ([]byte, http.Header, int, error) {
 	// get download url if not specified
 	if a.DownloadURL == "" {
 		a.DownloadURL = DownloadURL
-		if err != nil {
-			return
-		}
 	}
 
 	inHeaders := http.Header{}
 	inHeaders.Add("Accept", "application/json")
 
-	return web.Request(a.Client, a.DownloadURL, http.MethodGet, inHeaders, nil, 5*time.Second)
+	return web.Request(a.Client, a.DownloadURL, http.MethodGet, inHeaders, nil, web.ShortRequestTimeout)
 }
 
-func (a *AWS) Fetch() (doc Doc, etag string, err error) {
+func (a *AWS) Fetch() (Doc, string, error) {
 	data, headers, _, err := a.FetchData()
 	if err != nil {
-		return
+		return Doc{}, "", err
 	}
 
-	etag = headers.Get("Etag")
+	etag := headers.Get("Etag")
 	if etag != "" && len(etag) > 2 {
 		TrimQuotes(&etag)
 	}
 
-	doc, err = ProcessData(data)
+	doc, err := ProcessData(data)
 
-	return
+	return doc, etag, err
 }
 
-func ProcessData(data []byte) (doc Doc, err error) {
+func ProcessData(data []byte) (Doc, error) {
 	var rawDoc RawDoc
-	err = json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return
+	if err := json.Unmarshal(data, &rawDoc); err != nil {
+		return Doc{}, err
 	}
 
-	doc.Prefixes, err = castV4Entries(rawDoc.Prefixes)
+	prefixes, err := castV4Entries(rawDoc.Prefixes)
 	if err != nil {
-		return
+		return Doc{}, err
 	}
 
-	doc.IPv6Prefixes, err = castV6Entries(rawDoc.IPv6Prefixes)
+	ipv6Prefixes, err := castV6Entries(rawDoc.IPv6Prefixes)
 	if err != nil {
-		return
+		return Doc{}, err
 	}
 
-	doc.CreateDate = rawDoc.CreateDate
-	doc.SyncToken = rawDoc.SyncToken
-
-	return
+	return Doc{
+		Prefixes:     prefixes,
+		IPv6Prefixes: ipv6Prefixes,
+		CreateDate:   rawDoc.CreateDate,
+		SyncToken:    rawDoc.SyncToken,
+	}, nil
 }
 
-func castV4Entries(entries []RawPrefix) (res []Prefix, err error) {
+func castV4Entries(entries []RawPrefix) ([]Prefix, error) {
+	var res []Prefix
 	for _, entry := range entries {
-		var p netip.Prefix
-		p, err = netip.ParsePrefix(entry.IPPrefix)
+		p, err := netip.ParsePrefix(entry.IPPrefix)
 		if err != nil {
-			return
+			return res, err
 		}
 
 		res = append(res, Prefix{
@@ -168,15 +163,15 @@ func castV4Entries(entries []RawPrefix) (res []Prefix, err error) {
 		})
 	}
 
-	return
+	return res, nil
 }
 
-func castV6Entries(entries []RawIPv6Prefix) (res []IPv6Prefix, err error) {
+func castV6Entries(entries []RawIPv6Prefix) ([]IPv6Prefix, error) {
+	var res []IPv6Prefix
 	for _, entry := range entries {
-		var p netip.Prefix
-		p, err = netip.ParsePrefix(entry.IPv6Prefix)
+		p, err := netip.ParsePrefix(entry.IPv6Prefix)
 		if err != nil {
-			return
+			return res, err
 		}
 
 		res = append(res, IPv6Prefix{
@@ -186,7 +181,7 @@ func castV6Entries(entries []RawIPv6Prefix) (res []IPv6Prefix, err error) {
 		})
 	}
 
-	return
+	return res, nil
 }
 
 func TrimQuotes(in *string) {

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/Danny-Dasilva/CycleTLS/cycletls"
 
@@ -118,7 +117,7 @@ func (a *Azure) GetDownloadURL() (string, error) {
 	return url, nil
 }
 
-func (a *Azure) FetchData() (data []byte, headers http.Header, status int, err error) {
+func (a *Azure) FetchData() ([]byte, http.Header, int, error) {
 	// get download url if not specified
 	if a.DownloadURL == "" {
 		a.DownloadURL = WorkaroundDownloadURL
@@ -132,7 +131,7 @@ func (a *Azure) FetchData() (data []byte, headers http.Header, status int, err e
 	// 	a.DownloadURL = WorkaroundDownloadURL
 	// }
 
-	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, 5*time.Second)
+	data, headers, status, err := web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, web.ShortRequestTimeout)
 	if status >= http.StatusBadRequest {
 		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
 	}
@@ -140,20 +139,20 @@ func (a *Azure) FetchData() (data []byte, headers http.Header, status int, err e
 	return data, headers, status, err
 }
 
-func (a *Azure) Fetch() (doc Doc, md5 string, err error) {
+func (a *Azure) Fetch() (Doc, string, error) {
 	data, headers, _, err := a.FetchData()
 	if err != nil {
-		return
+		return Doc{}, "", err
 	}
 
-	err = json.Unmarshal(data, &doc)
-	if err != nil {
-		return
+	var doc Doc
+	if err = json.Unmarshal(data, &doc); err != nil {
+		return Doc{}, "", err
 	}
 
-	md5 = headers.Get("Content-MD5")
+	md5 := headers.Get("Content-MD5")
 
-	return
+	return doc, md5, nil
 }
 
 type Doc struct {

--- a/providers/bingbot/bingbot.go
+++ b/providers/bingbot/bingbot.go
@@ -47,7 +47,7 @@ func (bb *Bingbot) FetchData() (data []byte, headers http.Header, status int, er
 	if bb.DownloadURL == "" {
 		bb.DownloadURL = DownloadURL
 	}
-	return web.Request(bb.Client, bb.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(bb.Client, bb.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (bb *Bingbot) Fetch() (doc Doc, err error) {

--- a/providers/cloudflare/cloudflare.go
+++ b/providers/cloudflare/cloudflare.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"net/http"
 	"net/netip"
-	"time"
 
 	"github.com/jonhadfield/ip-fetcher/internal/pflog"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
@@ -45,70 +44,67 @@ type Cloudflare struct {
 	IPv6DownloadURL string
 }
 
-func (cf *Cloudflare) FetchIPv4Data() (data []byte, headers http.Header, status int, err error) {
+func (cf *Cloudflare) FetchIPv4Data() ([]byte, http.Header, int, error) {
 	if cf.IPv4DownloadURL == "" {
 		cf.IPv4DownloadURL = DefaultIPv4URL
 	}
 
-	return web.Request(cf.Client, cf.IPv4DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(cf.Client, cf.IPv4DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
-func (cf *Cloudflare) FetchIPv6Data() (data []byte, headers http.Header, status int, err error) {
+func (cf *Cloudflare) FetchIPv6Data() ([]byte, http.Header, int, error) {
 	if cf.IPv6DownloadURL == "" {
 		cf.IPv6DownloadURL = DefaultIPv6URL
 	}
 
-	return web.Request(cf.Client, cf.IPv6DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(cf.Client, cf.IPv6DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
-func (cf *Cloudflare) Fetch4() (prefixes []netip.Prefix, err error) {
+func (cf *Cloudflare) Fetch4() ([]netip.Prefix, error) {
 	data, _, _, err := cf.FetchIPv4Data()
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	return ProcessData(data)
 }
 
-func (cf *Cloudflare) Fetch6() (prefixes []netip.Prefix, err error) {
+func (cf *Cloudflare) Fetch6() ([]netip.Prefix, error) {
 	data, _, _, err := cf.FetchIPv6Data()
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	return ProcessData(data)
 }
 
-func (cf *Cloudflare) Fetch() (prefixes []netip.Prefix, err error) {
+func (cf *Cloudflare) Fetch() ([]netip.Prefix, error) {
 	p4, err := cf.Fetch4()
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	p6, err := cf.Fetch6()
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	return append(p4, p6...), err
+	return append(p4, p6...), nil
 }
 
-func ProcessData(data []byte) (prefixes []netip.Prefix, err error) {
+func ProcessData(data []byte) ([]netip.Prefix, error) {
 	r := bytes.NewReader(data)
 
 	scanner := bufio.NewScanner(r)
+	var prefixes []netip.Prefix
 	for scanner.Scan() {
-		// fmt.Println(scanner.Text()) // Println will add back the final '\n'
-
-		var prefix netip.Prefix
-
-		prefix, err = netip.ParsePrefix(scanner.Text())
+		prefix, err := netip.ParsePrefix(scanner.Text())
 		if err != nil {
-			return
+			return nil, err
 		}
 
 		prefixes = append(prefixes, prefix)
 	}
 
-	return
+	return prefixes, nil
 }

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -42,13 +42,13 @@ func New() DigitalOcean {
 	}
 }
 
-func (a *DigitalOcean) FetchData() (data []byte, headers http.Header, status int, err error) {
+func (a *DigitalOcean) FetchData() ([]byte, http.Header, int, error) {
 	// get download url if not specified
 	if a.DownloadURL == "" {
 		a.DownloadURL = DigitaloceanDownloadURL
 	}
 
-	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, 5*time.Second)
+	data, headers, status, err := web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, web.ShortRequestTimeout)
 	if status >= http.StatusBadRequest {
 		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
 	}
@@ -62,17 +62,18 @@ type Doc struct {
 	Records      []Record
 }
 
-func (a *DigitalOcean) Fetch() (doc Doc, err error) {
+func (a *DigitalOcean) Fetch() (Doc, error) {
 	data, headers, _, err := a.FetchData()
 	if err != nil {
-		return
+		return Doc{}, err
 	}
 
 	records, err := Parse(data)
 	if err != nil {
-		return
+		return Doc{}, err
 	}
 
+	var doc Doc
 	doc.Records = records
 
 	var etag string
@@ -89,13 +90,13 @@ func (a *DigitalOcean) Fetch() (doc Doc, err error) {
 	lastModifiedRaw := headers.Values(web.LastModifiedHeader)
 	if len(lastModifiedRaw) != 0 {
 		if lastModifiedTime, err = time.Parse(time.RFC1123, lastModifiedRaw[0]); err != nil {
-			return
+			return Doc{}, err
 		}
 	}
 
 	doc.LastModified = lastModifiedTime
 
-	return doc, err
+	return doc, nil
 }
 
 type Entry struct {

--- a/providers/fastly/fastly.go
+++ b/providers/fastly/fastly.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/netip"
-	"time"
 
 	"github.com/jonhadfield/ip-fetcher/internal/pflog"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
@@ -46,7 +45,7 @@ func (f *Fastly) FetchData() (data []byte, headers http.Header, status int, err 
 		f.DownloadURL = DownloadURL
 	}
 
-	return web.Request(f.Client, f.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(f.Client, f.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (f *Fastly) Fetch() (doc Doc, err error) {

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -49,54 +49,57 @@ type RawDoc struct {
 	Entries       []json.RawMessage `json:"prefixes"`
 }
 
-func (gc *GCP) FetchData() (data []byte, headers http.Header, status int, err error) {
+func (gc *GCP) FetchData() ([]byte, http.Header, int, error) {
 	if gc.DownloadURL == "" {
 		gc.DownloadURL = DownloadURL
 	}
 
-	return web.Request(gc.Client, gc.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(gc.Client, gc.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
-func (gc *GCP) Fetch() (doc Doc, err error) {
+func (gc *GCP) Fetch() (Doc, error) {
 	data, _, _, err := gc.FetchData()
 	if err != nil {
-		return
+		return Doc{}, err
 	}
 
 	return ProcessData(data)
 }
 
-func ProcessData(data []byte) (doc Doc, err error) {
+func ProcessData(data []byte) (Doc, error) {
 	var rawDoc RawDoc
-	err = json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return
+	if err := json.Unmarshal(data, &rawDoc); err != nil {
+		return Doc{}, err
 	}
 
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
+	ipv4, ipv6, err := castEntries(rawDoc.Entries)
 	if err != nil {
-		return
+		return Doc{}, err
 	}
 
 	ct, err := time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
 	if err != nil {
-		return
+		return Doc{}, err
 	}
 
-	doc.CreationTime = ct
-	doc.SyncToken = rawDoc.SyncToken
-
-	return
+	return Doc{
+		CreationTime: ct,
+		SyncToken:    rawDoc.SyncToken,
+		IPv4Prefixes: ipv4,
+		IPv6Prefixes: ipv6,
+	}, nil
 }
 
-func castEntries(prefixes []json.RawMessage) (ipv4 []IPv4Entry, ipv6 []IPv6Entry, err error) {
+func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
+	var ipv4 []IPv4Entry
+	var ipv6 []IPv6Entry
 	for _, pr := range prefixes {
 		var ipv4entry RawIPv4Entry
 
 		var ipv6entry RawIPv6Entry
 
 		// try 4
-		err = json.Unmarshal(pr, &ipv4entry)
+		err := json.Unmarshal(pr, &ipv4entry)
 		if err == nil {
 			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
 			if parseError == nil {
@@ -128,11 +131,11 @@ func castEntries(prefixes []json.RawMessage) (ipv4 []IPv4Entry, ipv6 []IPv6Entry
 		}
 
 		if err != nil {
-			return
+			return ipv4, ipv6, err
 		}
 	}
 
-	return
+	return ipv4, ipv6, nil
 }
 
 type RawIPv4Entry struct {

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -53,7 +53,7 @@ func (gc *Google) FetchData() (data []byte, headers http.Header, status int, err
 	if gc.DownloadURL == "" {
 		gc.DownloadURL = DownloadURL
 	}
-	return web.Request(gc.Client, gc.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(gc.Client, gc.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (gc *Google) Fetch() (doc Doc, err error) {

--- a/providers/googlebot/googlebot.go
+++ b/providers/googlebot/googlebot.go
@@ -52,7 +52,7 @@ func (gc *Googlebot) FetchData() (data []byte, headers http.Header, status int, 
 	if gc.DownloadURL == "" {
 		gc.DownloadURL = DownloadURL
 	}
-	return web.Request(gc.Client, gc.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(gc.Client, gc.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (gc *Googlebot) Fetch() (doc Doc, err error) {

--- a/providers/googlesc/googlesc.go
+++ b/providers/googlesc/googlesc.go
@@ -52,7 +52,7 @@ func (gs *Googlesc) FetchData() (data []byte, headers http.Header, status int, e
 	if gs.DownloadURL == "" {
 		gs.DownloadURL = DownloadURL
 	}
-	return web.Request(gs.Client, gs.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(gs.Client, gs.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (gs *Googlesc) Fetch() (doc Doc, err error) {

--- a/providers/hetzner/hetzner.go
+++ b/providers/hetzner/hetzner.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/netip"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jonhadfield/ip-fetcher/internal/pflog"
@@ -104,7 +103,7 @@ func (h *Hetzner) FetchData() (data []byte, headers http.Header, status int, err
 		url = fmt.Sprintf(url, asn)
 
 		var body []byte
-		body, headers, status, err = web.Request(h.Client, url, http.MethodGet, nil, nil, 10*time.Second)
+		body, headers, status, err = web.Request(h.Client, url, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("error fetching ASN %s: %w", asn, err)
 		}

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -89,7 +89,7 @@ func (a *Linode) FetchData() (data []byte, headers http.Header, status int, err 
 		a.DownloadURL = DownloadURL
 	}
 
-	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, 5*time.Second)
+	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, web.ShortRequestTimeout)
 	if status >= http.StatusBadRequest {
 		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
 	}

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -114,7 +114,7 @@ func (ora *OCI) FetchData() (data []byte, headers http.Header, status int, err e
 		ora.DownloadURL = DownloadURL
 	}
 
-	return web.Request(ora.Client, ora.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(ora.Client, ora.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (ora *OCI) Fetch() (doc Doc, err error) {

--- a/providers/ovh/ovh.go
+++ b/providers/ovh/ovh.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"net/http"
 	"net/netip"
-	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jonhadfield/ip-fetcher/internal/pflog"
@@ -45,7 +44,7 @@ func (o *OVH) FetchData() (data []byte, headers http.Header, status int, err err
 		o.DownloadURL = DownloadURL
 	}
 
-	return web.Request(o.Client, o.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(o.Client, o.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (o *OVH) Fetch() (prefixes []netip.Prefix, err error) {

--- a/providers/url/url.go
+++ b/providers/url/url.go
@@ -2,6 +2,7 @@ package url
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/netip"
@@ -304,7 +305,7 @@ func (c *Client) get(url *url.URL, header http.Header) (result UrlResponse, err 
 	var data []byte
 	var status int
 
-	data, _, status, err = web.Request(c.HttpClient, url.String(), http.MethodGet, header, nil, 10*time.Second)
+	data, _, status, err = web.Request(c.HttpClient, url.String(), http.MethodGet, header, nil, web.DefaultRequestTimeout)
 	if err != nil {
 		logrus.Debug(err.Error())
 	}
@@ -324,7 +325,7 @@ func fetchUrlResponse(client *retryablehttp.Client, url string) (result UrlRespo
 	var data []byte
 	var status int
 
-	data, _, status, err = web.Request(client, url, http.MethodGet, nil, nil, 10*time.Second)
+	data, _, status, err = web.Request(client, url, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 	if err != nil {
 		logrus.Debug(err.Error())
 	}
@@ -356,7 +357,7 @@ func (c *Client) Get(requests []Request) (*[]UrlResponse, error) {
 	}
 
 	if len(requests) == 0 {
-		return nil, fmt.Errorf("no URLs to fetch")
+		return nil, errors.New("no URLs to fetch")
 	}
 
 	var err error
@@ -384,9 +385,7 @@ func (hf *HttpFiles) FetchUrls() (results []UrlResponse, err error) {
 	}
 
 	if len(hf.Urls) == 0 {
-		err = fmt.Errorf("no URLs to fetch")
-
-		return
+		return nil, errors.New("no URLs to fetch")
 	}
 
 	for _, hfUrl := range hf.Urls {

--- a/providers/zscaler/zscaler.go
+++ b/providers/zscaler/zscaler.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"net/http"
 	"net/netip"
-	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jonhadfield/ip-fetcher/internal/pflog"
@@ -45,7 +44,7 @@ func (z *Zscaler) FetchData() (data []byte, headers http.Header, status int, err
 		z.DownloadURL = DownloadURL
 	}
 
-	return web.Request(z.Client, z.DownloadURL, http.MethodGet, nil, nil, 10*time.Second)
+	return web.Request(z.Client, z.DownloadURL, http.MethodGet, nil, nil, web.DefaultRequestTimeout)
 }
 
 func (z *Zscaler) Fetch() (prefixes []netip.Prefix, err error) {


### PR DESCRIPTION
## Summary
- refactor `internal/web` helpers to drop named return args
- use `errors.New` for static error messages
- add constants for request timeouts
- replace magic duration literals with constants across providers
- cleanup unused imports and adjust error checks

## Testing
- `go test ./...` *(fails: open testdata files, network requests)*

------
https://chatgpt.com/codex/tasks/task_e_683c98e403108320b345f8e1c639a8a8