### PR TITLE
Add provider docs and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Please raise an issue if you have any issues or suggestions for new providers.
 - <a href="https://www.akamai.com" target="_blank">Akamai</a>
 - <a href="https://www.hetzner.com" target="_blank">Hetzner</a>
 - <a href="https://www.github.com" target="_blank">GitHub</a>
+- <a href="https://www.linode.com" target="_blank">Linode</a>
+- <a href="https://www.oracle.com/cloud/" target="_blank">Oracle Cloud Infrastructure</a>
+- <a href="https://support.apple.com/en-us/HT212614" target="_blank">iCloud Private Relay</a>
 - <a href="https://www.ovhcloud.com" target="_blank">OVHcloud</a>
 - <a href="https://www.zscaler.com" target="_blank">Zscaler</a>
 

--- a/providers/akamai/akamai_test.go
+++ b/providers/akamai/akamai_test.go
@@ -1,0 +1,45 @@
+package akamai_test
+
+import (
+	"fmt"
+	"net/netip"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/jonhadfield/ip-fetcher/providers/akamai"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestProcessData(t *testing.T) {
+	data, err := os.ReadFile("testdata/prefixes.txt")
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	prefixes, err := akamai.ProcessData(data)
+	require.NoError(t, err)
+	require.Len(t, prefixes, 2)
+	require.Contains(t, prefixes, netip.MustParsePrefix("203.0.113.0/24"))
+	require.Contains(t, prefixes, netip.MustParsePrefix("2001:db8::/32"))
+}
+
+func TestFetch(t *testing.T) {
+	u, err := url.Parse(akamai.DownloadURL)
+	require.NoError(t, err)
+	urlBase := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+
+	gock.New(urlBase).
+		Get(u.Path).
+		Reply(200).
+		File("testdata/prefixes.txt")
+
+	a := akamai.New()
+	gock.InterceptClient(a.Client.HTTPClient)
+
+	prefixes, err := a.Fetch()
+	require.NoError(t, err)
+	require.Len(t, prefixes, 2)
+	require.Contains(t, prefixes, netip.MustParsePrefix("203.0.113.0/24"))
+	require.Contains(t, prefixes, netip.MustParsePrefix("2001:db8::/32"))
+}

--- a/providers/zscaler/zscaler_test.go
+++ b/providers/zscaler/zscaler_test.go
@@ -1,0 +1,45 @@
+package zscaler_test
+
+import (
+	"fmt"
+	"net/netip"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/jonhadfield/ip-fetcher/providers/zscaler"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestProcessData(t *testing.T) {
+	data, err := os.ReadFile("testdata/prefixes.txt")
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	prefixes, err := zscaler.ProcessData(data)
+	require.NoError(t, err)
+	require.Len(t, prefixes, 2)
+	require.Contains(t, prefixes, netip.MustParsePrefix("198.51.100.0/24"))
+	require.Contains(t, prefixes, netip.MustParsePrefix("2001:db8:2::/48"))
+}
+
+func TestFetch(t *testing.T) {
+	u, err := url.Parse(zscaler.DownloadURL)
+	require.NoError(t, err)
+	urlBase := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+
+	gock.New(urlBase).
+		Get(u.Path).
+		Reply(200).
+		File("testdata/prefixes.txt")
+
+	z := zscaler.New()
+	gock.InterceptClient(z.Client.HTTPClient)
+
+	prefixes, err := z.Fetch()
+	require.NoError(t, err)
+	require.Len(t, prefixes, 2)
+	require.Contains(t, prefixes, netip.MustParsePrefix("198.51.100.0/24"))
+	require.Contains(t, prefixes, netip.MustParsePrefix("2001:db8:2::/48"))
+}


### PR DESCRIPTION
## Summary
- document Linode, OCI, and iCloud Private Relay providers
- add Akamai tests
- add Zscaler tests

## Testing
- `go test ./...` *(fails: undefined identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_6840000bc3588320a278f32f8eb49993