### PR TITLE
Fix depguard lints

### DIFF
--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/netip"
 	"time"
@@ -112,12 +111,12 @@ func Parse(data []byte) ([]Record, error) {
 
 	header, err := csvutil.Header(Entry{}, "csv")
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	dec, err := csvutil.NewDecoder(r, header...)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	var records []Record

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -168,12 +167,12 @@ func Parse(data []byte) ([]Record, error) {
 
 	doHeader, err := csvutil.Header(Entry{}, "csv")
 	if err != nil {
-		log.Fatal(err)
+		return records, err
 	}
 
 	dec, err := csvutil.NewDecoder(csvReader, doHeader...)
 	if err != nil {
-		log.Fatal(err)
+		return records, err
 	}
 
 Loop:

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -168,12 +167,12 @@ func Parse(data []byte) ([]Record, error) {
 
 	doHeader, err := csvutil.Header(Entry{}, "csv")
 	if err != nil {
-		log.Fatal(err)
+		return records, err
 	}
 
 	dec, err := csvutil.NewDecoder(csvReader, doHeader...)
 	if err != nil {
-		log.Fatal(err)
+		return records, err
 	}
 
 Loop:


### PR DESCRIPTION
## Summary
- remove standard log import from several providers
- return errors instead of log.Fatal when parsing provider CSV data

## Testing
- `golangci-lint run ./... | head -n 20`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844b9732a148320b9d1a8afa51ef0bd