### PR TITLE
Refactor repeated strings into constants

### DIFF
--- a/cmd/ip-fetcher/abuseipdb.go
+++ b/cmd/ip-fetcher/abuseipdb.go
@@ -44,18 +44,18 @@ func abuseipdbCmd() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -79,7 +79,7 @@ func abuseipdbCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/akamai.go
+++ b/cmd/ip-fetcher/akamai.go
@@ -30,18 +30,18 @@ func akamaiCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -73,7 +73,7 @@ func akamaiCmd() *cli.Command {
 				if err != nil {
 					return err
 				}
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/alibaba.go
+++ b/cmd/ip-fetcher/alibaba.go
@@ -31,11 +31,11 @@ func alibabaCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -43,7 +43,7 @@ func alibabaCmd() *cli.Command {
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
 
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 
 				os.Exit(1)
 			}
@@ -87,7 +87,7 @@ func alibabaCmd() *cli.Command {
 				if err != nil {
 					return err
 				}
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/aws.go
+++ b/cmd/ip-fetcher/aws.go
@@ -31,11 +31,11 @@ func awsCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -43,7 +43,7 @@ func awsCmd() *cli.Command {
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
 
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 
 				os.Exit(1)
 			}
@@ -78,7 +78,7 @@ func awsCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/azure.go
+++ b/cmd/ip-fetcher/azure.go
@@ -35,11 +35,11 @@ func azureCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -47,7 +47,7 @@ func azureCmd() *cli.Command {
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
 
-				fmt.Println("\nerror: must specify at least one of stdout and Path") //nolint:forbidigo
+				fmt.Println("\n" + errStdoutOrPathRequired) //nolint:forbidigo
 
 				os.Exit(1)
 			}
@@ -88,7 +88,7 @@ func azureCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out)) //nolint:forbidigo
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out)) //nolint:forbidigo
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/bingbot.go
+++ b/cmd/ip-fetcher/bingbot.go
@@ -32,18 +32,18 @@ func bingbotCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -76,7 +76,7 @@ func bingbotCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/cloudflare.go
+++ b/cmd/ip-fetcher/cloudflare.go
@@ -38,7 +38,7 @@ func cloudflareCmd() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 			&cli.BoolFlag{
 				Name:  "4",
@@ -61,7 +61,7 @@ func cloudflareCmd() *cli.Command {
 				// nolint:errcheck
 				_ = cli.ShowSubcommandHelp(c)
 
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 

--- a/cmd/ip-fetcher/constants.go
+++ b/cmd/ip-fetcher/constants.go
@@ -1,0 +1,8 @@
+package main
+
+const (
+	errStdoutOrPathRequired = "error: must specify at least one of stdout and Path"
+	usageWriteToStdout      = "write to stdout"
+	usageWhereToSaveFile    = "where to save the file"
+	fmtDataWrittenTo        = "Data written to %s\n"
+)

--- a/cmd/ip-fetcher/digitalocean.go
+++ b/cmd/ip-fetcher/digitalocean.go
@@ -26,18 +26,18 @@ func digitaloceanCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -71,7 +71,7 @@ func digitaloceanCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/fastly.go
+++ b/cmd/ip-fetcher/fastly.go
@@ -36,11 +36,11 @@ func fastlyCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 			&cli.StringFlag{
 				Name:  "format",
@@ -51,7 +51,7 @@ func fastlyCmd() *cli.Command {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -126,7 +126,7 @@ func fastlyOutput(doc fastly.Doc, format string, stdout bool, path string) error
 			return err
 		}
 
-		if _, err = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out)); err != nil {
+		if _, err = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out)); err != nil {
 			return err
 		}
 	}

--- a/cmd/ip-fetcher/gcp.go
+++ b/cmd/ip-fetcher/gcp.go
@@ -34,11 +34,11 @@ func gcpCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 			&cli.StringFlag{
 				Name:  "format",
@@ -49,7 +49,7 @@ func gcpCmd() *cli.Command {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -118,7 +118,7 @@ func output(doc gcp.Doc, format string, stdout bool, path string) error {
 			return err
 		}
 
-		if _, err = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out)); err != nil {
+		if _, err = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out)); err != nil {
 			return err
 		}
 	}

--- a/cmd/ip-fetcher/github.go
+++ b/cmd/ip-fetcher/github.go
@@ -30,12 +30,12 @@ func githubCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "Path",
-				Usage:   "where to save the file",
+				Usage:   usageWhereToSaveFile,
 				Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:    "stdout",
-				Usage:   "write to stdout",
+				Usage:   usageWriteToStdout,
 				Aliases: []string{"s"},
 			},
 		},
@@ -43,7 +43,7 @@ func githubCmd() *cli.Command {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -81,7 +81,7 @@ func githubCmd() *cli.Command {
 				if err != nil {
 					return err
 				}
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/google.go
+++ b/cmd/ip-fetcher/google.go
@@ -31,18 +31,18 @@ func googleCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -75,7 +75,7 @@ func googleCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/googlebot.go
+++ b/cmd/ip-fetcher/googlebot.go
@@ -32,18 +32,18 @@ func googlebotCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -76,7 +76,7 @@ func googlebotCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/googlesc.go
+++ b/cmd/ip-fetcher/googlesc.go
@@ -32,18 +32,18 @@ func googlescCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -76,7 +76,7 @@ func googlescCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/googleutf.go
+++ b/cmd/ip-fetcher/googleutf.go
@@ -32,18 +32,18 @@ func googleutfCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -76,7 +76,7 @@ func googleutfCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/hetzner.go
+++ b/cmd/ip-fetcher/hetzner.go
@@ -31,11 +31,11 @@ func hetznerCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -43,7 +43,7 @@ func hetznerCmd() *cli.Command {
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
 
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 
 				os.Exit(1)
 			}
@@ -87,7 +87,7 @@ func hetznerCmd() *cli.Command {
 				if err != nil {
 					return err
 				}
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/icloudpr.go
+++ b/cmd/ip-fetcher/icloudpr.go
@@ -35,18 +35,18 @@ func iCloudPRCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -79,7 +79,7 @@ func iCloudPRCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/linode.go
+++ b/cmd/ip-fetcher/linode.go
@@ -34,18 +34,18 @@ func linodeCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"},
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"},
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -78,7 +78,7 @@ func linodeCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/oci.go
+++ b/cmd/ip-fetcher/oci.go
@@ -33,11 +33,11 @@ func ociCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -45,7 +45,7 @@ func ociCmd() *cli.Command {
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
 
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 
 				os.Exit(1)
 			}
@@ -80,7 +80,7 @@ func ociCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/ovh.go
+++ b/cmd/ip-fetcher/ovh.go
@@ -30,12 +30,12 @@ func ovhCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "Path",
-				Usage:   "where to save the file",
+				Usage:   usageWhereToSaveFile,
 				Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:    "stdout",
-				Usage:   "write to stdout",
+				Usage:   usageWriteToStdout,
 				Aliases: []string{"s"},
 			},
 		},
@@ -43,7 +43,7 @@ func ovhCmd() *cli.Command {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -81,7 +81,7 @@ func ovhCmd() *cli.Command {
 				if err != nil {
 					return err
 				}
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/url.go
+++ b/cmd/ip-fetcher/url.go
@@ -32,11 +32,11 @@ func urlCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -45,7 +45,7 @@ func urlCmd() *cli.Command {
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
 
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 
 				os.Exit(1)
 			}
@@ -97,7 +97,7 @@ func urlCmd() *cli.Command {
 					return err
 				}
 
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {

--- a/cmd/ip-fetcher/zscaler.go
+++ b/cmd/ip-fetcher/zscaler.go
@@ -30,18 +30,18 @@ func zscalerCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "Path",
-				Usage: "where to save the file", Aliases: []string{"p"}, TakesFile: true,
+				Usage: usageWhereToSaveFile, Aliases: []string{"p"}, TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "stdout",
-				Usage: "write to stdout", Aliases: []string{"s"},
+				Usage: usageWriteToStdout, Aliases: []string{"s"},
 			},
 		},
 		Action: func(c *cli.Context) error {
 			path := strings.TrimSpace(c.String("Path"))
 			if path == "" && !c.Bool("stdout") {
 				_ = cli.ShowSubcommandHelp(c)
-				fmt.Println("\nerror: must specify at least one of stdout and Path")
+				fmt.Println("\n" + errStdoutOrPathRequired)
 				os.Exit(1)
 			}
 
@@ -73,7 +73,7 @@ func zscalerCmd() *cli.Command {
 				if err != nil {
 					return err
 				}
-				_, _ = os.Stderr.WriteString(fmt.Sprintf("Data written to %s\n", out))
+				_, _ = os.Stderr.WriteString(fmt.Sprintf(fmtDataWrittenTo, out))
 			}
 
 			if c.Bool("stdout") {


### PR DESCRIPTION
## Summary
- deduplicate command help messages and file output formats
- add common constants for string reuse

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68457ba0cf2c8320813efcaa4653cfe8