### PR TITLE
Fix Fastly env variable name

### DIFF
--- a/cmd/ip-fetcher/fastly.go
+++ b/cmd/ip-fetcher/fastly.go
@@ -57,7 +57,7 @@ func fastlyCmd() *cli.Command {
 
 			a := fastly.New()
 
-			if os.Getenv("IP_FETCHER_MOCK_Fastly") == "true" {
+			if os.Getenv("IP_FETCHER_MOCK_FASTLY") == "true" {
 				defer gock.Off()
 				urlBase := fastly.DownloadURL
 				u, _ := url.Parse(urlBase)


### PR DESCRIPTION
## Summary
- standardize mocking env var for Fastly to `IP_FETCHER_MOCK_FASTLY`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849f818cd0c8320ac60aee41c4fb2f4