### PR TITLE
Add web response tests and fix OVH fixtures

### DIFF
--- a/internal/web/web_getresponsebody_test.go
+++ b/internal/web/web_getresponsebody_test.go
@@ -1,0 +1,36 @@
+package web_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/jonhadfield/ip-fetcher/internal/web"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetResponseBodyPlain(t *testing.T) {
+	body := io.NopCloser(bytes.NewBufferString("hello"))
+	resp := &http.Response{Body: body, Header: http.Header{}}
+
+	data, err := web.GetResponseBody(resp)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), data)
+}
+
+func TestGetResponseBodyGzip(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	body := io.NopCloser(&buf)
+	resp := &http.Response{Body: body, Header: http.Header{"Content-Encoding": {"gzip"}}}
+
+	data, err := web.GetResponseBody(resp)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), data)
+}

--- a/providers/ovh/testdata/prefixes.json
+++ b/providers/ovh/testdata/prefixes.json
@@ -1,0 +1,47 @@
+{
+  "status": "ok",
+  "status_message": "Query was successful",
+  "data": {
+    "ipv4_prefixes": [
+      {
+        "prefix": "192.0.2.0/24",
+        "ip": "192.0.2.0",
+        "cidr": 16,
+        "roa_status": "Valid",
+        "name": "DE-HETZNER-20120425",
+        "description": "Hetzner Online GmbH",
+        "country_code": "DE",
+        "parent": {
+          "prefix": "192.0.2.0/24",
+          "ip": "192.0.2.0",
+          "cidr": 16,
+          "rir_name": "RIPE",
+          "allocation_status": "unknown"
+        }
+      }
+    ],
+    "ipv6_prefixes": [
+      {
+        "prefix": "2001:db8::/32",
+        "ip": "2001:db8::",
+        "cidr": 32,
+        "roa_status": "Valid",
+        "name": null,
+        "description": null,
+        "country_code": null,
+        "parent": {
+          "prefix": null,
+          "ip": null,
+          "cidr": null,
+          "rir_name": null,
+          "allocation_status": "unknown"
+        }
+      }
+    ]
+  },
+  "@meta": {
+    "time_zone": "UTC",
+    "api_version": 1,
+    "execution_time": "53.15 ms"
+  }
+}


### PR DESCRIPTION
## Summary
- add new tests for `internal/web` `GetResponseBody`
- provide OVH `prefixes.json` fixture so provider tests run

## Testing
- `go test ./providers/ovh -run TestFetch -v`
- `go test ./internal/web -run GetResponseBody -v`
- `go test ./internal/web ./providers/ovh -v`
- `go test ./...` *(fails: Get https://storage.googleapis.com ... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ea9ca304483208fcf63508aa0cbd3