### PR TITLE
Refactor header constants

### DIFF
--- a/cmd/ip-fetcher/cloudflare.go
+++ b/cmd/ip-fetcher/cloudflare.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jonhadfield/ip-fetcher/internal/web"
 	"github.com/jonhadfield/ip-fetcher/providers/cloudflare"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/h2non/gock.v1"
@@ -78,13 +79,13 @@ func cloudflareCmd() *cli.Command {
 				gock.New(url4Base).
 					Get(u4.Path).
 					Reply(http.StatusOK).
-					AddHeader("Last-Modified", exTimeStamp).
+					AddHeader(web.LastModifiedHeader, exTimeStamp).
 					File("../../providers/cloudflare/testdata/ips-v4")
 				url6Base := fmt.Sprintf("%s://%s", u6.Scheme, u6.Host)
 				gock.New(url6Base).
 					Get(u6.Path).
 					Reply(http.StatusOK).
-					AddHeader("Last-Modified", exTimeStamp).
+					AddHeader(web.LastModifiedHeader, exTimeStamp).
 					File("../../providers/cloudflare/testdata/ips-v6")
 
 				gock.InterceptClient(cf.Client.HTTPClient)

--- a/internal/web/constants.go
+++ b/internal/web/constants.go
@@ -2,4 +2,7 @@ package web
 
 const (
 	LastModifiedHeader = "Last-Modified"
+	ContentMD5Header   = "Content-MD5"
+	ETagHeader         = "ETag"
+	EtagHeader         = "etag"
 )

--- a/providers/abuseipdb/abuseipdb_test.go
+++ b/providers/abuseipdb/abuseipdb_test.go
@@ -61,7 +61,7 @@ func TestFetchBlackListData(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		MatchHeaders(map[string]string{"Key": "test-key", "Accept": "application/json"}).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/blacklist")
 
 	gock.InterceptClient(ac.Client.HTTPClient)
@@ -84,7 +84,7 @@ func TestFetchBlackList(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		MatchHeaders(map[string]string{"Key": "test-key", "Accept": "application/json"}).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/blacklist")
 
 	gock.InterceptClient(ac.Client.HTTPClient)

--- a/providers/akamai/akamai_test.go
+++ b/providers/akamai/akamai_test.go
@@ -2,6 +2,7 @@ package akamai_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"os"
@@ -31,7 +32,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/prefixes.txt")
 
 	a := akamai.New()

--- a/providers/alibaba/alibaba_test.go
+++ b/providers/alibaba/alibaba_test.go
@@ -2,6 +2,7 @@ package alibaba_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 	urlBase := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/prefixes.json")
 
 	ac := hetzner.New()

--- a/providers/aws/aws_test.go
+++ b/providers/aws/aws_test.go
@@ -2,6 +2,7 @@ package aws_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestGetIPListETag(t *testing.T) {
 	gock.New(urlBase).
 		Head(u.Path).
 		MatchHeaders(map[string]string{"Accept": "application/json"}).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("Etag", "0338bd4dc4ba7a050b9124d333376fc7")
 
 	ac := aws.New()
@@ -44,7 +45,7 @@ func TestDownloadIPList(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		MatchHeaders(map[string]string{"Accept": "application/json"}).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("Etag", "\"cd5e4f079775994d8e49f63ae9a84065\"").
 		File("testdata/ip-ranges.json")
 
@@ -67,7 +68,7 @@ func TestDownloadIPListWithoutQuotedEtag(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		MatchHeaders(map[string]string{"Accept": "application/json"}).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("Etag", "dd5e4f079775994d8e49f63ae9a84065").
 		File("testdata/ip-ranges.json")
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -157,7 +157,7 @@ func (a *Azure) Fetch() (Doc, string, error) {
 		return Doc{}, "", err
 	}
 
-	md5 := headers.Get("Content-MD5")
+	md5 := headers.Get(web.ContentMD5Header)
 
 	return doc, md5, nil
 }

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -2,6 +2,7 @@ package azure_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -29,7 +30,7 @@ const (
 // 	gock.New(urlBase).
 // 		MatchParam("id", "00000").
 // 		Get(u.Path).
-// 		Reply(200).
+// 		Reply(http.StatusOK).
 // 		File(testInitialFilePath)
 //
 // 	ac := New()
@@ -54,10 +55,10 @@ func TestFetchRaw(t *testing.T) {
 	exTimeStamp := "Tue, 13 Dec 2022 06:50:50 GMT"
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
-		AddHeader("Last-Modified", exTimeStamp).
-		AddHeader("Content-MD5", exMD5).
-		AddHeader("ETag", exEtag).
+		Reply(http.StatusOK).
+		AddHeader(web.LastModifiedHeader, exTimeStamp).
+		AddHeader(web.ContentMD5Header, exMD5).
+		AddHeader(web.ETagHeader, exEtag).
 		File(testDataFilePath)
 
 	ac := azure.New()
@@ -66,8 +67,8 @@ func TestFetchRaw(t *testing.T) {
 
 	data, header, status, err := ac.FetchData()
 	require.NoError(t, err)
-	require.Equal(t, 200, status)
-	require.Equal(t, exMD5, header.Get("Content-MD5"))
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, exMD5, header.Get(web.ContentMD5Header))
 	require.Len(t, data, 2938956)
 }
 
@@ -80,7 +81,7 @@ func TestFetchRawNoDownloadURL(t *testing.T) {
 	// intercept initial url
 	gock.New(testInitialURL).
 		Get(u.Path).
-		Reply(404)
+		Reply(http.StatusNotFound)
 
 	_, err = url.Parse(testInitialURL)
 
@@ -103,7 +104,7 @@ func TestFetchRawFailure(t *testing.T) {
 	urlBase := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(404).
+		Reply(http.StatusNotFound).
 		File(testDataFilePath)
 
 	ac := azure.New()
@@ -112,7 +113,7 @@ func TestFetchRawFailure(t *testing.T) {
 
 	data, _, status, err := ac.FetchData()
 	require.Error(t, err)
-	require.Equal(t, 404, status)
+	require.Equal(t, http.StatusNotFound, status)
 	require.Empty(t, data)
 }
 
@@ -157,10 +158,10 @@ func TestFetch(t *testing.T) {
 	exTimeStamp := "Tue, 13 Dec 2022 06:50:50 GMT"
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
-		AddHeader("Last-Modified", exTimeStamp).
-		AddHeader("Content-MD5", exMD5).
-		AddHeader("ETag", exEtag).
+		Reply(http.StatusOK).
+		AddHeader(web.LastModifiedHeader, exTimeStamp).
+		AddHeader(web.ContentMD5Header, exMD5).
+		AddHeader(web.ETagHeader, exEtag).
 		File(testDataFilePath)
 
 	ac := azure.New()

--- a/providers/bingbot/bingbot_test.go
+++ b/providers/bingbot/bingbot_test.go
@@ -2,6 +2,7 @@ package bingbot_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/bingbot.json")
 
 	ac := bingbot.New()

--- a/providers/cloudflare/cloudflare_test.go
+++ b/providers/cloudflare/cloudflare_test.go
@@ -2,6 +2,7 @@ package cloudflare_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch4(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/ips-v4")
 
 	cf := cloudflare.New()
@@ -39,7 +40,7 @@ func TestFetch6(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/ips-v6")
 
 	cf := cloudflare.New()
@@ -59,7 +60,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase6).
 		Get(u6.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/ips-v6")
 
 	u4, err := url.Parse(cloudflare.DefaultIPv4URL)
@@ -68,7 +69,7 @@ func TestFetch(t *testing.T) {
 	urlBase4 := fmt.Sprintf("%s://%s", u4.Scheme, u4.Host)
 	gock.New(urlBase4).
 		Get(u4.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/ips-v4")
 
 	cf := cloudflare.New()

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -85,7 +85,7 @@ func (a *DigitalOcean) Fetch() (Doc, error) {
 
 	var etag string
 
-	etags := headers.Values("etag")
+	etags := headers.Values(web.EtagHeader)
 	if len(etags) != 0 {
 		etag = etags[0]
 	}

--- a/providers/digitalocean/digitalocean_test.go
+++ b/providers/digitalocean/digitalocean_test.go
@@ -2,6 +2,7 @@ package digitalocean_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 	"time"
@@ -23,8 +24,8 @@ func TestFetchData(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
-		SetHeader("etag", etag).
+		Reply(http.StatusOK).
+		SetHeader(web.EtagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/google.csv")
 
@@ -34,11 +35,11 @@ func TestFetchData(t *testing.T) {
 	data, headers, status, err := ac.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values("etag"), 1)
-	require.Equal(t, etag, headers.Values("etag")[0])
+	require.Len(t, headers.Values(web.EtagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
-	require.Equal(t, 200, status)
+	require.Equal(t, http.StatusOK, status)
 }
 
 func TestFetch(t *testing.T) {
@@ -51,8 +52,8 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
-		SetHeader("etag", etag).
+		Reply(http.StatusOK).
+		SetHeader(web.EtagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/google.csv")
 

--- a/providers/fastly/fastly_test.go
+++ b/providers/fastly/fastly_test.go
@@ -2,6 +2,7 @@ package fastly_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -20,7 +21,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/fastly.json")
 
 	cf := fastly.New()

--- a/providers/gcp/gcp_test.go
+++ b/providers/gcp/gcp_test.go
@@ -2,6 +2,7 @@ package gcp_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		// SetHeader("Etag", "cd5e4f079775994d8e49f63ae9a84065").
 		File("testdata/cloud.json")
 

--- a/providers/github/github_test.go
+++ b/providers/github/github_test.go
@@ -2,6 +2,7 @@ package github_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/meta.json")
 
 	gh := github.New()

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -2,6 +2,7 @@ package google_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -22,7 +23,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/goog.json")
 
 	ac := google.New()

--- a/providers/googlebot/googlebot_test.go
+++ b/providers/googlebot/googlebot_test.go
@@ -2,6 +2,7 @@ package googlebot_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/googlebot.json")
 
 	ac := googlebot.New()

--- a/providers/googlesc/googlesc_test.go
+++ b/providers/googlesc/googlesc_test.go
@@ -2,6 +2,7 @@ package googlesc_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/special-crawlers.json")
 
 	sc := googlesc.New()

--- a/providers/googleutf/googleutf_test.go
+++ b/providers/googleutf/googleutf_test.go
@@ -2,6 +2,7 @@ package googleutf_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/user-triggered-fetchers.json")
 
 	sc := googleutf.New()

--- a/providers/hetzner/hetzner_test.go
+++ b/providers/hetzner/hetzner_test.go
@@ -2,6 +2,7 @@ package hetzner_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 	urlBase := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/prefixes.json")
 
 	ac := hetzner.New()

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -125,7 +125,7 @@ func (a *ICloudPrivateRelay) Fetch() (Doc, error) {
 
 	var etag string
 
-	etags := headers.Values("etag")
+	etags := headers.Values(web.EtagHeader)
 	if len(etags) != 0 {
 		etag = etags[0]
 	}

--- a/providers/icloudpr/icloudpr_test.go
+++ b/providers/icloudpr/icloudpr_test.go
@@ -2,6 +2,7 @@ package icloudpr_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -23,8 +24,8 @@ func TestFetchData(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
-		SetHeader("etag", etag).
+		Reply(http.StatusOK).
+		SetHeader(web.EtagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/egress-ip-ranges.csv")
 
@@ -35,11 +36,11 @@ func TestFetchData(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values("etag"), 1)
-	require.Equal(t, etag, headers.Values("etag")[0])
+	require.Len(t, headers.Values(web.EtagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
-	require.Equal(t, 200, status)
+	require.Equal(t, http.StatusOK, status)
 	require.Len(t, data, 323)
 }
 
@@ -54,8 +55,8 @@ func TestFetch(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		Times(2).
-		Reply(200).
-		SetHeader("etag", etag).
+		Reply(http.StatusOK).
+		SetHeader(web.EtagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/egress-ip-ranges.csv")
 
@@ -67,11 +68,11 @@ func TestFetch(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values("etag"), 1)
-	require.Equal(t, etag, headers.Values("etag")[0])
+	require.Len(t, headers.Values(web.EtagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
-	require.Equal(t, 200, status)
+	require.Equal(t, http.StatusOK, status)
 	require.Len(t, data, 323)
 
 	doc, err := ld.Fetch()

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -125,7 +125,7 @@ func (a *Linode) Fetch() (Doc, error) {
 
 	var etag string
 
-	etags := headers.Values("etag")
+	etags := headers.Values(web.EtagHeader)
 	if len(etags) != 0 {
 		etag = etags[0]
 	}

--- a/providers/linode/linode_test.go
+++ b/providers/linode/linode_test.go
@@ -2,6 +2,7 @@ package linode_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -23,8 +24,8 @@ func TestFetchData(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
-		SetHeader("etag", etag).
+		Reply(http.StatusOK).
+		SetHeader(web.EtagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/prefixes.csv")
 
@@ -35,11 +36,11 @@ func TestFetchData(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values("etag"), 1)
-	require.Equal(t, etag, headers.Values("etag")[0])
+	require.Len(t, headers.Values(web.EtagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
-	require.Equal(t, 200, status)
+	require.Equal(t, http.StatusOK, status)
 	require.Len(t, data, 681)
 }
 
@@ -54,8 +55,8 @@ func TestFetch(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		Times(2).
-		Reply(200).
-		SetHeader("etag", etag).
+		Reply(http.StatusOK).
+		SetHeader(web.EtagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/prefixes.csv")
 
@@ -67,11 +68,11 @@ func TestFetch(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values("etag"), 1)
-	require.Equal(t, etag, headers.Values("etag")[0])
+	require.Len(t, headers.Values(web.EtagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
-	require.Equal(t, 200, status)
+	require.Equal(t, http.StatusOK, status)
 	require.Len(t, data, 681)
 
 	doc, err := ld.Fetch()

--- a/providers/m247/m247_test.go
+++ b/providers/m247/m247_test.go
@@ -2,6 +2,7 @@ package m247_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/prefixes.json")
 
 	o := m247.New()

--- a/providers/maxmind/geoip/geoip_test.go
+++ b/providers/maxmind/geoip/geoip_test.go
@@ -2,6 +2,7 @@ package geoip_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -85,7 +86,7 @@ func TestDownloadDBFile(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -95,7 +96,7 @@ func TestDownloadDBFile(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-ASN-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
@@ -135,7 +136,7 @@ func TestDownloadDBFileMissingTargetDirectory(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -145,7 +146,7 @@ func TestDownloadDBFileMissingTargetDirectory(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-ASN-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
@@ -187,7 +188,7 @@ func TestFetchCityFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -197,7 +198,7 @@ func TestFetchCityFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-City-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
@@ -252,7 +253,7 @@ func TestFetchCityFilesWithoutExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -262,7 +263,7 @@ func TestFetchCityFilesWithoutExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-City-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
@@ -310,7 +311,7 @@ func TestFetchFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(uARN.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -320,7 +321,7 @@ func TestFetchFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(uARN.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-ASN-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
@@ -334,7 +335,7 @@ func TestFetchFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(uCity.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -344,7 +345,7 @@ func TestFetchFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(uCity.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-City-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
@@ -357,7 +358,7 @@ func TestFetchFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(uCountry.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-Country-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -367,7 +368,7 @@ func TestFetchFiles(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(uCountry.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-Country-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-Country-CSV_20220617.zip")
 
@@ -460,7 +461,7 @@ func TestDownloadExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(uARN.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -470,7 +471,7 @@ func TestDownloadExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(uARN.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-ASN-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-ASN-CSV_20220617.zip")
 
@@ -484,7 +485,7 @@ func TestDownloadExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(uCity.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -494,7 +495,7 @@ func TestDownloadExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(uCity.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-City-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
@@ -507,7 +508,7 @@ func TestDownloadExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(uCountry.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-Country-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -517,7 +518,7 @@ func TestDownloadExtract(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(uCountry.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-Country-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-Country-CSV_20220617.zip")
 
@@ -576,7 +577,7 @@ func TestDownloadExtractCityWithoutRoot(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Head(uCity.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 
 	gock.New(urlBase).
@@ -586,7 +587,7 @@ func TestDownloadExtractCityWithoutRoot(t *testing.T) {
 			"suffix":      "zip",
 		}).
 		Get(uCity.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/GeoLite2-City-CSV_20220617.zip").
 		SetHeader("content-disposition", "attachment; filename=GeoLite2-City-CSV_20220617.zip")
 

--- a/providers/oci/oci_test.go
+++ b/providers/oci/oci_test.go
@@ -2,6 +2,7 @@ package oci_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/public_ip_ranges.json")
 
 	ac := oci.New()

--- a/providers/ovh/ovh_test.go
+++ b/providers/ovh/ovh_test.go
@@ -2,6 +2,7 @@ package ovh_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -21,7 +22,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/prefixes.json")
 
 	o := ovh.New()

--- a/providers/scaleway/scaleway_test.go
+++ b/providers/scaleway/scaleway_test.go
@@ -2,6 +2,7 @@ package scaleway_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -21,7 +22,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/prefixes.json")
 
 	o := scaleway.New()

--- a/providers/url/url_test.go
+++ b/providers/url/url_test.go
@@ -31,7 +31,7 @@ func TestFetchUrlData(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/ip-file-1.txt")
 
 	hf := mUrl.New()
@@ -56,7 +56,7 @@ func TestFetchUrls(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/ip-file-1.txt")
 
 	hf := mUrl.New()

--- a/providers/vultr/vultr_test.go
+++ b/providers/vultr/vultr_test.go
@@ -2,6 +2,7 @@ package vultr_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/netip"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ func TestFetch(t *testing.T) {
 	urlBase := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/prefixes.json")
 
 	ac := vultr.New()

--- a/providers/zscaler/zscaler_test.go
+++ b/providers/zscaler/zscaler_test.go
@@ -2,6 +2,7 @@ package zscaler_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"testing"
@@ -28,7 +29,7 @@ func TestFetch(t *testing.T) {
 
 	gock.New(urlBase).
 		Get(u.Path).
-		Reply(200).
+		Reply(http.StatusOK).
 		File("testdata/doc.json")
 
 	z := zscaler.New()


### PR DESCRIPTION
## Summary
- add global header constants
- use web constants in fetchers and tests
- replace numeric status codes with http constants

## Testing
- `go test ./...` *(fails: forbidden access to storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684ea8fd6f4c83209eb3fa36809987a6