### PR TITLE
Add flat list output option

### DIFF
--- a/cmd/ip-fetcher/constants.go
+++ b/cmd/ip-fetcher/constants.go
@@ -4,5 +4,6 @@ const (
 	errStdoutOrPathRequired = "error: must specify at least one of stdout and Path"
 	usageWriteToStdout      = "write to stdout"
 	usageWhereToSaveFile    = "where to save the file"
+	usageLinesOutput        = "output newline separated ip prefixes"
 	fmtDataWrittenTo        = "Data written to %s\n"
 )

--- a/cmd/ip-fetcher/lines.go
+++ b/cmd/ip-fetcher/lines.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"net/netip"
+	"reflect"
+	"strings"
+)
+
+// docToLines converts any provider document or prefix slice to newline separated IP prefixes.
+func docToLines(doc any) ([]byte, error) {
+	var prefixes []string
+	addrType := reflect.TypeOf(netip.Addr{})
+	prefixType := reflect.TypeOf(netip.Prefix{})
+
+	var walk func(val reflect.Value)
+	walk = func(val reflect.Value) {
+		if !val.IsValid() {
+			return
+		}
+		if val.Type() == prefixType {
+			prefixes = append(prefixes, val.Interface().(netip.Prefix).String())
+			return
+		}
+		if val.Type() == addrType {
+			prefixes = append(prefixes, val.Interface().(netip.Addr).String())
+			return
+		}
+		switch val.Kind() {
+		case reflect.Ptr:
+			if !val.IsNil() {
+				walk(val.Elem())
+			}
+		case reflect.Struct:
+			for i := 0; i < val.NumField(); i++ {
+				walk(val.Field(i))
+			}
+		case reflect.Slice, reflect.Array:
+			for i := 0; i < val.Len(); i++ {
+				walk(val.Index(i))
+			}
+		}
+	}
+
+	walk(reflect.ValueOf(doc))
+
+	if len(prefixes) == 0 {
+		return nil, fmt.Errorf("no prefixes found")
+	}
+
+	sb := strings.Builder{}
+	for _, p := range prefixes {
+		sb.WriteString(p)
+		sb.WriteByte('\n')
+	}
+
+	return []byte(sb.String()), nil
+}


### PR DESCRIPTION
## Summary
- add generic helper to output newline-separated prefixes
- add `--lines` flag to various provider commands (aws, azure, digitalocean, gcp, fastly)
- document usage of new flag

## Testing
- `go test ./...` *(fails: storage.googleapis.com Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6857da3849e0832096136b7c04322f53