### PR TITLE
Reduce code smells

### DIFF
--- a/cmd/ip-fetcher/lines.go
+++ b/cmd/ip-fetcher/lines.go
@@ -9,6 +9,10 @@ import (
 
 // docToLines converts any provider document or prefix slice to newline separated IP prefixes.
 func docToLines(doc any) ([]byte, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("no prefixes found")
+	}
+
 	var prefixes []string
 	addrType := reflect.TypeOf(netip.Addr{})
 	prefixType := reflect.TypeOf(netip.Prefix{})
@@ -48,11 +52,7 @@ func docToLines(doc any) ([]byte, error) {
 		return nil, fmt.Errorf("no prefixes found")
 	}
 
-	sb := strings.Builder{}
-	for _, p := range prefixes {
-		sb.WriteString(p)
-		sb.WriteByte('\n')
-	}
+	joined := strings.Join(prefixes, "\n") + "\n"
 
-	return []byte(sb.String()), nil
+	return []byte(joined), nil
 }

--- a/internal/web/constants.go
+++ b/internal/web/constants.go
@@ -4,5 +4,4 @@ const (
 	LastModifiedHeader = "Last-Modified"
 	ContentMD5Header   = "Content-MD5"
 	ETagHeader         = "ETag"
-	EtagHeader         = "etag"
 )

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -192,7 +192,7 @@ func castV6Entries(entries []RawIPv6Prefix) ([]IPv6Prefix, error) {
 }
 
 func TrimQuotes(in *string) {
-	*in = strings.TrimPrefix(strings.TrimSuffix(*in, "\""), "\"")
+	*in = strings.Trim(*in, "\"")
 }
 
 type RawPrefix struct {

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -85,7 +85,7 @@ func (a *DigitalOcean) Fetch() (Doc, error) {
 
 	var etag string
 
-	etags := headers.Values(web.EtagHeader)
+	etags := headers.Values(web.ETagHeader)
 	if len(etags) != 0 {
 		etag = etags[0]
 	}

--- a/providers/digitalocean/digitalocean_test.go
+++ b/providers/digitalocean/digitalocean_test.go
@@ -25,7 +25,7 @@ func TestFetchData(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		Reply(http.StatusOK).
-		SetHeader(web.EtagHeader, etag).
+		SetHeader(web.ETagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/google.csv")
 
@@ -35,8 +35,8 @@ func TestFetchData(t *testing.T) {
 	data, headers, status, err := ac.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values(web.EtagHeader), 1)
-	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
+	require.Len(t, headers.Values(web.ETagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.ETagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
 	require.Equal(t, http.StatusOK, status)
@@ -53,7 +53,7 @@ func TestFetch(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		Reply(http.StatusOK).
-		SetHeader(web.EtagHeader, etag).
+		SetHeader(web.ETagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/google.csv")
 

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -125,7 +125,7 @@ func (a *ICloudPrivateRelay) Fetch() (Doc, error) {
 
 	var etag string
 
-	etags := headers.Values(web.EtagHeader)
+	etags := headers.Values(web.ETagHeader)
 	if len(etags) != 0 {
 		etag = etags[0]
 	}

--- a/providers/icloudpr/icloudpr_test.go
+++ b/providers/icloudpr/icloudpr_test.go
@@ -25,7 +25,7 @@ func TestFetchData(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		Reply(http.StatusOK).
-		SetHeader(web.EtagHeader, etag).
+		SetHeader(web.ETagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/egress-ip-ranges.csv")
 
@@ -36,8 +36,8 @@ func TestFetchData(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values(web.EtagHeader), 1)
-	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
+	require.Len(t, headers.Values(web.ETagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.ETagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
 	require.Equal(t, http.StatusOK, status)
@@ -56,7 +56,7 @@ func TestFetch(t *testing.T) {
 		Get(u.Path).
 		Times(2).
 		Reply(http.StatusOK).
-		SetHeader(web.EtagHeader, etag).
+		SetHeader(web.ETagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/egress-ip-ranges.csv")
 
@@ -68,8 +68,8 @@ func TestFetch(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values(web.EtagHeader), 1)
-	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
+	require.Len(t, headers.Values(web.ETagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.ETagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
 	require.Equal(t, http.StatusOK, status)

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -125,7 +125,7 @@ func (a *Linode) Fetch() (Doc, error) {
 
 	var etag string
 
-	etags := headers.Values(web.EtagHeader)
+	etags := headers.Values(web.ETagHeader)
 	if len(etags) != 0 {
 		etag = etags[0]
 	}

--- a/providers/linode/linode_test.go
+++ b/providers/linode/linode_test.go
@@ -25,7 +25,7 @@ func TestFetchData(t *testing.T) {
 	gock.New(urlBase).
 		Get(u.Path).
 		Reply(http.StatusOK).
-		SetHeader(web.EtagHeader, etag).
+		SetHeader(web.ETagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/prefixes.csv")
 
@@ -36,8 +36,8 @@ func TestFetchData(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values(web.EtagHeader), 1)
-	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
+	require.Len(t, headers.Values(web.ETagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.ETagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
 	require.Equal(t, http.StatusOK, status)
@@ -56,7 +56,7 @@ func TestFetch(t *testing.T) {
 		Get(u.Path).
 		Times(2).
 		Reply(http.StatusOK).
-		SetHeader(web.EtagHeader, etag).
+		SetHeader(web.ETagHeader, etag).
 		SetHeader(web.LastModifiedHeader, lastModified).
 		File("testdata/prefixes.csv")
 
@@ -68,8 +68,8 @@ func TestFetch(t *testing.T) {
 	data, headers, status, err := ld.FetchData()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Len(t, headers.Values(web.EtagHeader), 1)
-	require.Equal(t, etag, headers.Values(web.EtagHeader)[0])
+	require.Len(t, headers.Values(web.ETagHeader), 1)
+	require.Equal(t, etag, headers.Values(web.ETagHeader)[0])
 	require.Len(t, headers.Values(web.LastModifiedHeader), 1)
 	require.Equal(t, lastModified, headers.Values(web.LastModifiedHeader)[0])
 	require.Equal(t, http.StatusOK, status)


### PR DESCRIPTION
## Summary
- simplify prefix list extraction
- shrink TrimQuotes helper
- remove duplicate header constant
- update providers to use single header constant

## Testing
- `go test ./...` *(fails: github.com/klauspost/compress forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685973ea055483209b026e264ab53401