### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/providers/maxmind/geoip/geoip.go
+++ b/providers/maxmind/geoip/geoip.go
@@ -232,7 +232,12 @@ func UnzipFiles(src, dest string) (err error) {
 		return err
 	}
 
-	cleanDest := filepath.Clean(dest)
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+
+	cleanDest := filepath.Clean(absDest)
 	var totalUncompressed uint64
 
 	for _, file := range r.File {
@@ -255,14 +260,22 @@ func extractFile(f *zip.File, dest string, totalUncompressed *uint64) error {
 	}
 
 	relativePath := filepath.Clean(f.Name)
+	if filepath.IsAbs(relativePath) || filepath.VolumeName(relativePath) != "" {
+		return fmt.Errorf("illegal file path: %s", f.Name)
+	}
 	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("illegal file path: %s", f.Name)
 	}
 
 	targetPath := filepath.Join(dest, relativePath)
-	if !strings.HasPrefix(targetPath, dest+string(os.PathSeparator)) && targetPath != dest {
+	absTargetPath, err := filepath.Abs(targetPath)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(absTargetPath, dest+string(os.PathSeparator)) && absTargetPath != dest {
 		return fmt.Errorf("illegal file path: %s", f.Name)
 	}
+	targetPath = absTargetPath
 
 	rc, err := f.Open()
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/jonhadfield/ip-fetcher/security/code-scanning/1](https://github.com/jonhadfield/ip-fetcher/security/code-scanning/1)

Use canonical absolute-path validation for every extracted entry before any filesystem operation:

- Compute a safe destination root once (absolute + clean) in `UnzipFiles`.
- In `extractFile`, reject:
  - absolute archive entry names (`filepath.IsAbs`),
  - names with non-empty volume (`filepath.VolumeName`, relevant on Windows),
  - entries that resolve outside `dest` after `Join` + `Abs`.
- Keep existing size checks and extraction behavior unchanged.

Concretely in `providers/maxmind/geoip/geoip.go`:
1. In `UnzipFiles`, replace `cleanDest := filepath.Clean(dest)` with an absolute canonical destination (`absDest, err := filepath.Abs(dest)` then `cleanDest := filepath.Clean(absDest)`).
2. In `extractFile`, after cleaning `f.Name`, add explicit absolute/volume checks.
3. Replace the current prefix check with one based on `filepath.Abs(filepath.Join(dest, relativePath))` and then containment check against `dest` using a separator-suffixed prefix (or exact match).

No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
