### PR TITLE
add a test workflow to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+  pull_request:
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+      - name: go test
+        run: go test -covermode=atomic -coverprofile=coverage.txt -timeout=600s ./...
+      - name: coverage
+        run: go tool cover -func=coverage.txt | tail -1


### PR DESCRIPTION
Adds a `go test` job. CI currently runs golangci-lint, CodeQL and Sonar,
but never runs the tests.

```yaml
go test -covermode=atomic -coverprofile=coverage.txt -timeout=600s ./...
```

Triggers, Go version and action versions match the existing
`golangci-lint.yml`, so this behaves the same way on pushes to `main`, on
tags and on pull requests. The coverage step prints the total as a one line
summary; nothing consumes `coverage.txt` yet, as `sonar-project.properties`
sets no Go coverage path.

### Why this was needed

`main` was broken and nothing noticed. Before #115 landed, this job failed
with:

```
--- FAIL: TestAzureCmdSavetoPath
--- FAIL: TestAzureCmdStdOut
--- FAIL: TestAzureCmdStdOutAndFile
    gock: cannot match any request
    ServiceTags_Public_20260817.json
```

The azure CLI mock did not pin the download URL, so `FetchData` ran live
discovery through cycletls, which gock cannot intercept. Discovery returned
whichever dated snapshot Microsoft currently advertises, while the mock was
registered against the hardcoded `WorkaroundDownloadURL`, so the request
never matched. It broke silently when Microsoft rotated the file, and
golangci-lint, CodeQL and Sonar all passed over it.

#115 has since fixed that and this branch is rebased onto it, so the job
should now be green. The first run on this branch is what demonstrated the
gap, reproducing the failure identically on CI's Linux runner and locally.

### Known flakiness to watch

`providers/azure` reaches the network during tests even after #115.
`TestFetchRawNoDownloadURL` leaves `DownloadURL` empty on purpose to
exercise the discovery path, and cycletls bypasses gock, so that test makes
a real request to microsoft.com and takes ~15-25s. It is not a new problem
and it does not fail today, but it is the most likely source of flakes once
tests run on every PR.

`-race` is deliberately not enabled. The suite uses gomonkey for function
patching and several cmd tests re-exec the test binary, so turning it on
wants its own change rather than riding along here.