### PR TITLE
report go coverage to sonar

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,6 +13,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+      # sonar.go.coverage.reportPaths points at coverage.txt, which is
+      # generated rather than committed, so it has to be produced here.
+      - name: go test
+        run: go test -covermode=atomic -coverprofile=coverage.txt -timeout=600s ./...
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
 sonar.projectKey=jonhadfield_ip-fetcher
 sonar.organization=jonhadfield
 sonar.projectName=ip-fetcher
+sonar.go.coverage.reportPaths=coverage.txt


### PR DESCRIPTION
Points Sonar at a Go coverage report, so the quality gate stops failing on
coverage that was never actually measured.

### The problem

Every PR fails the gate on `0.0% Coverage on New Code (required >= 80%)`,
including #113 and #115. That is not a reflection of the tests - it is that
nothing ever handed Sonar a coverage report, so it correctly measured
nothing.

### The change

`sonar-project.properties` gains:

```properties
sonar.go.coverage.reportPaths=coverage.txt
```

That alone would be inert. `coverage.txt` is in `.gitignore`, so it is
generated rather than committed, and the SonarCloud job only did a checkout
before scanning - the file would never exist. So the job now sets up Go and
produces the profile before the scan:

```yaml
- name: go test
  run: go test -covermode=atomic -coverprofile=coverage.txt -timeout=600s ./...
```

Verified locally that this emits the standard Go cover format Sonar reads -
a `mode: atomic` header and fully qualified package paths.

### Tradeoff

The suite now runs twice per PR, once in `test.yml` and once here, adding
roughly three minutes. The alternative is to move the SonarCloud scan into
`test.yml` after its existing coverage step, so the tests run once. That is
tidier but renames the checks, which matters if any branch protection or
required-check config refers to them, so it is left as a separate decision.

### Not addressed

The gate's other failing condition is `Duplication on New Code` (16.6% on
#115, 46.0% on #113, against a 3% threshold). That one is real: the
per-provider architecture duplicates `FetchData`/`Fetch`/`ProcessData`
scaffolding and the publisher files by design. Worth a conversation about
either the threshold or `sonar.cpd.exclusions`, but it is not a coverage
problem and is out of scope here.