### PR TITLE
stop the azure tests reaching the live download page

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -30,6 +30,33 @@ type Azure struct {
 	InitialURL  string
 	DownloadURL string
 	Timeout     time.Duration
+
+	// PageFetcher retrieves the download page during discovery. It defaults to
+	// FetchPageWithCycleTLS and is exported so tests can replace it: cycletls
+	// does not use the shared http.Client, so gock cannot intercept it and any
+	// test exercising discovery would otherwise reach the live page.
+	PageFetcher PageFetcher
+}
+
+// PageFetcher retrieves a page, returning its body and HTTP status.
+type PageFetcher func(url string) (body string, status int, err error)
+
+// FetchPageWithCycleTLS retrieves the download page using a spoofed TLS
+// fingerprint, which the download site requires.
+func FetchPageWithCycleTLS(url string) (string, int, error) {
+	client := cycletls.Init()
+	defer client.Close()
+
+	response, err := client.Do(url, cycletls.Options{
+		Body:      "",
+		Ja3:       "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0",
+		UserAgent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",
+	}, "GET")
+	if err != nil {
+		return "", 0, err
+	}
+
+	return response.Body, response.Status, nil
 }
 
 func (a *Azure) ShortName() string {
@@ -50,9 +77,10 @@ func (a *Azure) SourceURL() string {
 
 func New() Azure {
 	return Azure{
-		InitialURL: InitialURL,
-		Client:     web.NewHTTPClientWithLogger(),
-		Timeout:    web.DefaultRequestTimeout,
+		InitialURL:  InitialURL,
+		Client:      web.NewHTTPClientWithLogger(),
+		Timeout:     web.DefaultRequestTimeout,
+		PageFetcher: FetchPageWithCycleTLS,
 	}
 }
 
@@ -61,53 +89,42 @@ func (a *Azure) GetDownloadURL() (string, error) {
 		a.InitialURL = InitialURL
 	}
 
-	client := cycletls.Init()
-	defer client.Close()
+	if a.PageFetcher == nil {
+		a.PageFetcher = FetchPageWithCycleTLS
+	}
 
-	var url string
-
-	response, err := client.Do(a.InitialURL, cycletls.Options{
-		Body:      "",
-		Ja3:       "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0",
-		UserAgent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",
-	}, "GET")
+	body, status, err := a.PageFetcher(a.InitialURL)
 	if err != nil {
 		return "", errors.New(errFailedToDownload)
 	}
 
-	if response.Status >= http.StatusBadRequest {
-		return url, errors.New(errFailedToDownload)
+	if status >= http.StatusBadRequest {
+		return "", errors.New(errFailedToDownload)
 	}
 
-	body := response.Body
+	return ParseDownloadURL(body), nil
+}
 
+// ParseDownloadURL extracts the first download.microsoft.com link from the
+// download page, returning an empty string if the page holds none.
+func ParseDownloadURL(body string) string {
 	reATags := regexp.MustCompile("<a [^>]+>")
-
-	aTags := reATags.FindAllString(body, -1)
-
 	reHRefs := regexp.MustCompile("href=\"[^\"]+\"")
+	reDownloadURL := regexp.MustCompile("(http|https)://[^\"]+")
 
-	var hrefs []string
+	for _, aTag := range reATags.FindAllString(body, -1) {
+		for _, hrefMatch := range reHRefs.FindAllString(aTag, -1) {
+			if !strings.Contains(hrefMatch, "download.microsoft.com/download/") {
+				continue
+			}
 
-	for _, href := range aTags {
-		hrefMatches := reHRefs.FindAllString(href, -1)
-		for _, hrefMatch := range hrefMatches {
-			if strings.Contains(hrefMatch, "download.microsoft.com/download/") {
-				hrefs = append(hrefs, hrefMatch)
+			if url := reDownloadURL.FindString(hrefMatch); url != "" {
+				return url
 			}
 		}
 	}
 
-	reDownloadURL := regexp.MustCompile("(http|https)://[^\"]+")
-
-	for _, href := range hrefs {
-		url = reDownloadURL.FindString(href)
-		if url != "" {
-			break
-		}
-	}
-
-	return url, nil
+	return ""
 }
 
 func (a *Azure) FetchData() ([]byte, http.Header, int, error) {

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -1,9 +1,11 @@
 package azure_test
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/jonhadfield/ip-fetcher/providers/azure"
@@ -22,28 +24,54 @@ const (
 	testDataFilePath    = "testdata/ServiceTags_Public_20221212.json"
 )
 
-// func TestGetDownloadURL(t *testing.T) {
-// 	defer gock.Off()
-//
-// 	u, err := url.Parse(testInitialURL)
-// 	require.NoError(t, err)
-//
-// 	urlBase := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
-// 	gock.New(urlBase).
-// 		MatchParam("id", "00000").
-// 		Get(u.Path).
-// 		Reply(http.StatusOK).
-// 		File(testInitialFilePath)
-//
-// 	ac := New()
-// 	ac.InitialURL = testInitialURL
-// 	gock.InterceptClient(ac.Client.HTTPClient)
-//
-// 	dURL, err := ac.GetDownloadURL()
-// 	require.NoError(t, err)
-// 	require.NotEmpty(t, dURL)
-// 	require.Equal(t, "https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_2000000.json", dURL)
-// }
+// stubPage returns a PageFetcher serving fixed content, standing in for the
+// cycletls call so discovery can be tested without reaching the live page.
+func stubPage(body string, status int, err error) azure.PageFetcher {
+	return func(string) (string, int, error) {
+		return body, status, err
+	}
+}
+
+func TestGetDownloadURL(t *testing.T) {
+	page, err := os.ReadFile(testInitialFilePath)
+	require.NoError(t, err)
+
+	ac := azure.New()
+	ac.InitialURL = testInitialURL
+	ac.PageFetcher = stubPage(string(page), http.StatusOK, nil)
+
+	dURL, err := ac.GetDownloadURL()
+	require.NoError(t, err)
+	require.Equal(t,
+		"https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_2000000.json",
+		dURL)
+}
+
+// a failing fetch is reported rather than silently yielding an empty URL.
+func TestGetDownloadURLFetchError(t *testing.T) {
+	ac := azure.New()
+	ac.InitialURL = testInitialURL
+	ac.PageFetcher = stubPage("", 0, errors.New("boom"))
+
+	_, err := ac.GetDownloadURL()
+	require.Error(t, err)
+}
+
+func TestGetDownloadURLBadStatus(t *testing.T) {
+	ac := azure.New()
+	ac.InitialURL = testInitialURL
+	ac.PageFetcher = stubPage("", http.StatusNotFound, nil)
+
+	_, err := ac.GetDownloadURL()
+	require.Error(t, err)
+}
+
+// a page with no download link yields an empty URL, which FetchData treats as
+// a discovery failure and falls back on.
+func TestParseDownloadURLNoLink(t *testing.T) {
+	require.Empty(t, azure.ParseDownloadURL(`<a href="https://example.com/nope">x</a>`))
+	require.Empty(t, azure.ParseDownloadURL(""))
+}
 
 func TestFetchRaw(t *testing.T) {
 	defer gock.Off()
@@ -74,27 +102,29 @@ func TestFetchRaw(t *testing.T) {
 	require.Len(t, data, 2938956)
 }
 
+// with no DownloadURL set, FetchData runs discovery. The page fetch is stubbed
+// as failing so it falls back to WorkaroundDownloadURL, which gock can serve.
 func TestFetchRawNoDownloadURL(t *testing.T) {
 	defer gock.Off()
 
-	u, err := url.Parse(testInitialURL)
+	u, err := url.Parse(azure.WorkaroundDownloadURL)
 	require.NoError(t, err)
 
-	// intercept initial url
-	gock.New(testInitialURL).
+	gock.New(fmt.Sprintf("%s://%s", u.Scheme, u.Host)).
 		Get(u.Path).
-		Reply(http.StatusNotFound)
-
-	_, err = url.Parse(testInitialURL)
-
-	require.NoError(t, err)
+		Reply(http.StatusOK).
+		File(testDataFilePath)
 
 	ac := azure.New()
 	ac.InitialURL = testInitialURL
+	ac.PageFetcher = stubPage("", http.StatusNotFound, nil)
 	gock.InterceptClient(ac.Client.HTTPClient)
 
-	_, _, _, err = ac.FetchData()
-	require.Error(t, err)
+	data, _, status, err := ac.FetchData()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, data)
+	require.Equal(t, azure.WorkaroundDownloadURL, ac.DownloadURL)
 }
 
 func TestFetchRawFailure(t *testing.T) {


### PR DESCRIPTION
Stops the azure provider tests reaching the live download page, and covers
the scraping logic that was untested as a result.

|  | before | after |
| --- | --- | --- |
| `providers/azure` runtime | 22.4s | 1.4s |
| `providers/azure` coverage | 47.9% | 68.8% |

### Root cause

`GetDownloadURL` called `cycletls.Init()` inline. cycletls does not use the
shared `http.Client`, so `gock.InterceptClient` cannot reach it and any test
exercising discovery hit `microsoft.com` for real. That is why
`TestGetDownloadURL` was commented out in the test file, which left the
HTML scraping completely untested.

Now that CI runs tests on every PR, this was the most likely source of
flakes: a network round trip plus retries on every run.

### The change

`Azure` gains a `PageFetcher` field:

```go
type PageFetcher func(url string) (body string, status int, err error)
```

It defaults to a new exported `FetchPageWithCycleTLS`, which holds the
existing JA3 and user-agent spoofing unchanged, and `GetDownloadURL` calls
through it. The field is nil-guarded, so a zero value `Azure{}` still works.

It is exported rather than unexported because the repo's `testpackage`
linter requires external test packages, so `azure_test` could not otherwise
reach it.

The HTML scraping is split out into a pure `ParseDownloadURL(body string)
string`, which is what makes the regex logic testable at all.

No behaviour change: the default path is byte for byte the same request it
made before.

### Tests

- `TestFetchRawNoDownloadURL` stubs a failing page fetch so discovery falls
  back to `WorkaroundDownloadURL`, which gock can serve, and now asserts the
  fallback actually happened rather than just that an error surfaced.
- `TestGetDownloadURL` is restored, against the existing `initial.html`
  fixture, and asserts the extracted URL.
- Added cases for fetch error, bad status, and a page holding no download
  link.

### Verifying no network remains

Timing alone is not proof, so with `HTTPS_PROXY`, `HTTP_PROXY` and
`ALL_PROXY` all pointed at `127.0.0.1:1`, the package still passes in 1.19s.
Any real outbound call would have failed or hung. All seven `azure.New()`
call sites in the test file are also guarded by either a stubbed
`PageFetcher` or an explicit `DownloadURL`, so none can fall through to live
discovery.

### Still reaches the network elsewhere

This covers `providers/azure`. The discovery path itself still uses cycletls
in production, which is deliberate - the download site requires the spoofed
fingerprint.