### PR TITLE
pin a go toolchain floor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/jonhadfield/ip-fetcher
 
 go 1.25.0
 
+toolchain go1.25.14
+
 require (
 	github.com/Danny-Dasilva/CycleTLS/cycletls v1.0.30
 	github.com/agiledragon/gomonkey/v2 v2.14.0


### PR DESCRIPTION
Pins a toolchain floor so builds pick up the patched standard library.

```
 go 1.25.0
+toolchain go1.25.14
```

### Result

`govulncheck ./...` before and after, on the same tree:

```
before:  Your code is affected by 26 vulnerabilities from the Go standard library.
after:   Your code is affected by 0 vulnerabilities.
```

Those 26 were in `crypto/tls`, `crypto/x509`, `net/http`, `net/url` and
`encoding/asn1`. Dependabot does not track the standard library, so none of
them appeared in its alerts - they only surfaced through govulncheck. With
#116 having cleared the third party modules, this closes the remainder.

The 2 findings that remain are in modules we require but never call.

### Why `toolchain` and not `go`

`go 1.25.0` is deliberately left alone. This is a library, and the `go`
directive is the minimum language version imposed on everyone who imports
it, so raising it would force consumers onto 1.25.14. `toolchain` sets the
floor for building this module only, which is what we actually want.

1.25.14 rather than the 1.25.13 govulncheck strictly requires, so it is the
current patch release and does not need revisiting immediately.

### Compatibility

The switch is automatic under the default `GOTOOLCHAIN=auto`: `go build`
fetched and used 1.25.14 without any intervention.

Nothing else pins a Go version in a way that conflicts. All three workflows
use `go-version: '1.25'`, which setup-go resolves to the latest 1.25.x, and
the Dockerfile builds `FROM golang:latest`.

### Testing

`go build ./...`, `go vet ./...`, `gofmt -l .` and `golangci-lint run ./...`
(0 issues) all clean under the new toolchain, and the full suite passes.