### PR TITLE
pin actions to commit shas

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.25'
           cache: false
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: latest
           args: -v --disable lll --disable dupl --disable gochecknoglobals

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     -
       name: Log in to ghcr
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -24,7 +24,7 @@ jobs:
 
     -
       name: Login to DockerHub
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
 
     -
       name: build image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
 #         context: ./docker
         file: ./Dockerfile
@@ -52,7 +52,7 @@ jobs:
           ghcr.io/${{ github.repository }}:${{ env.TAG }}
 
     - name: trivy image scan
-      uses: aquasecurity/trivy-action@v0.36.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: ${{ github.repository }}:latest
         exit-code: 0
@@ -60,7 +60,7 @@ jobs:
 
     -
       name: push image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
 #         context: ./docker
         file: ./Dockerfile

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,11 +10,11 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.25'
       # sonar.go.coverage.reportPaths points at coverage.txt, which is
@@ -22,7 +22,7 @@ jobs:
       - name: go test
         run: go test -covermode=atomic -coverprofile=coverage.txt -timeout=600s ./...
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@ba3875ecf642b2129de2b589510c81a8b53dbf4e # master — repo archived, see SonarSource/sonarqube-scan-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.25'
       - name: go test


### PR DESCRIPTION
Pins all 18 action references across the five workflows to commit SHAs.

A tag is mutable. If an action is retagged or its account compromised, CI
runs different code with no change here - and these workflows build and
publish releases, so that reaches users. This is the rule that failed #121
three times; it only applied there because those lines were new, so every
existing reference escaped it.

Each pin keeps its version as a trailing comment, which is the form
dependabot understands, so bumps still arrive as normal PRs:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

### Pinned

| action | version | sha |
| --- | --- | --- |
| actions/checkout | v7 | `3d3c42e5` |
| actions/setup-go | v7 | `b7ad1dad` |
| golangci/golangci-lint-action | v9 | `ba0d7d2e` |
| github/codeql-action (init, autobuild, analyze) | v4 | `db488dde` |
| docker/login-action | v4 | `dbcb8138` |
| docker/build-push-action | v7 | `53b7df96` |
| aquasecurity/trivy-action | v0.36.0 | `ed142fd0` |
| SonarSource/sonarcloud-github-action | master | `ba3875ec` |

`golang/govulncheck-action` was already pinned in #121.

Every SHA was verified back against its repository and tag before
committing, rather than trusted from a single lookup.

### One that deserves attention

`SonarSource/sonarcloud-github-action` was referenced as `@master` - a
mutable *branch*, the weakest form of reference. That repository is also
**archived**, and its description reads "Deprecated. Use
SonarSource/sonarqube-scan-action instead."

Its `master` is ahead of its last release (v5.0.0, February 2025), so CI has
been running unreleased code from an archived repository on every push.

This PR pins `master` as it stands today, which changes nothing about what
runs - pinning the v5.0.0 tag instead would have rolled the scanner
backwards. Migrating to `sonarqube-scan-action` is the real fix and is left
as a separate change, since it alters configuration rather than just
pinning.

### Testing

YAML validated for all five workflows. The CI run on this PR is the check
worth watching, since it exercises every pinned action except the release
workflow, which only runs on tags.