### PR TITLE
migrate to sonarqube-scan-action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -21,8 +21,10 @@ jobs:
       # generated rather than committed, so it has to be produced here.
       - name: go test
         run: go test -covermode=atomic -coverprofile=coverage.txt -timeout=600s ./...
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@ba3875ecf642b2129de2b589510c81a8b53dbf4e # master — repo archived, see SonarSource/sonarqube-scan-action
+      # SONAR_HOST_URL is not set: it is only required for a self hosted
+      # SonarQube Server, not for SonarQube Cloud.
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Replaces the archived `SonarSource/sonarcloud-github-action` with the
official `SonarSource/sonarqube-scan-action`.

```diff
-        uses: SonarSource/sonarcloud-github-action@ba3875ec… # master
+        uses: SonarSource/sonarqube-scan-action@22918119… # v8.2.1
```

### Why

The old action's repository is **archived**, and its description reads
"Deprecated. Use SonarSource/sonarqube-scan-action instead." Until #122 it
was referenced as `@master` - a mutable branch - and that branch sits ahead
of its last release (v5.0.0, February 2025), so every push was scanned by
unreleased code from an abandoned repository. #122 froze it at a known
commit; this removes it.

### Configuration

Deliberately minimal, per the new action's documented SonarQube Cloud setup:

- **`SONAR_HOST_URL` is not set.** It is required only for a self hosted
  SonarQube Server, not for SonarQube Cloud. Setting it would be wrong here.
- **`sonar-project.properties` is unchanged.** It already carries
  `sonar.organization` and `sonar.projectKey`, which is what the new action
  expects, and the `sonar.go.coverage.reportPaths` line added in #118 is
  untouched.
- **The `go test` coverage step is unchanged**, so coverage reporting keeps
  working.
- **`fetch-depth: 0` on checkout is retained**, still recommended for
  analysis relevancy.

`GITHUB_TOKEN` is kept even though the official quick-start example omits
it. The existing comment says it is needed for PR information, and dropping
it risks breaking PR decoration silently - that is a separate change to make
deliberately rather than as a side effect of this migration.

The new action is pinned to a commit SHA, consistent with #122, and the SHA
was verified against the v8.2.1 tag.

### What to watch on this PR

The Sonar checks themselves are the test. Two things worth confirming rather
than assuming:

1. the analysis completes and the quality gate reports at all, and
2. **coverage is still measured** - it should stay near the 62.8% established
   in #118. A drop to 0.0% would mean the new action is not picking up
   `coverage.txt`.