### PR TITLE
scope sonar analysis to real source

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,19 @@
 sonar.projectKey=jonhadfield_ip-fetcher
 sonar.organization=jonhadfield
 sonar.projectName=ip-fetcher
+
+sonar.sources=.
+sonar.tests=.
+
+# testdata holds provider response fixtures, not code. Analysing them counted
+# 106k lines of json as source, more than five times the go in this repo, which
+# distorted every ratio metric.
+sonar.exclusions=**/testdata/**,**/*_test.go
+sonar.test.exclusions=**/testdata/**
+
+# test files are tests, not production source. Left as source they contributed
+# 46% of all reported duplication while being 6% of the code, because each
+# provider's tests are deliberately near identical.
+sonar.test.inclusions=**/*_test.go
+
 sonar.go.coverage.reportPaths=coverage.txt


### PR DESCRIPTION
The quality gate has been failing on coverage and duplication for every code
PR. Investigating it, the thresholds turned out not to be the problem - what
was being measured was.

### The thresholds cannot be changed anyway

The project uses the **Sonar way** gate, which is built in and therefore not
editable:

```
new_coverage LT 80      new_duplicated_lines_density GT 3
```

Changing those would mean creating a custom gate in SonarQube Cloud and
assigning it to the project, which needs admin access there rather than a
change in this repository. Fortunately it is not needed.

### What was actually wrong

**1. Test fixtures were analysed as source code.**

Of roughly 126,000 lines Sonar measured, **106,358 were `testdata` fixtures**
- five sixths of the "codebase". A single file,
`providers/azure/testdata/ServiceTags_Public_20221212.json`, is 103,748
lines.

| language | ncloc |
| --- | --- |
| json (nearly all `testdata`) | 106,241 |
| go | 20,368 |

Every ratio metric was computed against that denominator, and each new
fixture counted as new code.

**2. Test files were indexed as production source.**

They are 6% of the code but produced **46% of all reported duplication**,
because each provider's CLI tests run the same four scenarios by design.

| | duplicated lines | ncloc |
| --- | --- | --- |
| `*_test.go` | 2,514 | 7,075 |
| real source | 2,954 | 119,961 |

Excluding tests drops duplicated lines from 5,468 to 2,954.

### Correction: this raises the reported duplication, it does not lower it

An earlier revision of this description claimed source duplication would be
about 2.5% and so pass the 3% gate. That was wrong - it divided source
duplicated lines by the *inflated* total, five sixths of which was json,
rather than by go source lines.

Measured properly:

| | before | after |
| --- | --- | --- |
| duplicated lines | 5,468 | 2,954 |
| duplicated lines density | 4.1% | **17.5%** |

The fixtures were **masking** real duplication, not causing a false alarm.
Removing 106k lines of json shrinks the denominator far more than the
numerator, so the true figure surfaces.

That duplication is real and sits in the providers: `linode` and `icloudpr`
are 90% duplicated against each other, and the crawler providers
(`ahrefs`, `applebot`, `duckduckbot`, `perplexitybot`, `googlebot`,
`googlesc`, `googleutf`, `anthropic`) run 50-60% each. `publisher/` does not
even reach the top 15, despite being the boilerplate I would have guessed.

This PR is therefore worth merging for accurate measurement, but it does
**not** make the duplication gate pass. That needs either a custom quality
gate with a threshold this architecture can meet, or a decision to reduce
the duplication itself.

### The change

`sonar-project.properties` gains a proper analysis scope: `testdata`
excluded from analysis entirely, and `*_test.go` declared as tests rather
than sources. This is the standard Go setup and it makes the existing
thresholds achievable rather than weakening them.

Coverage reporting from #118 is unchanged.

### What to watch

`ncloc` should fall from ~126k to ~20k, and duplication on new code should
drop sharply. Coverage will *move* - the denominator no longer includes test
files - so the figure will differ from the 62.9% seen previously. That is
expected and more accurate, not a regression.

### Not addressed

Genuinely untestable code, such as the cycletls network shim in
`providers/azure`, still counts against new-code coverage. That is a real
signal and is deliberately left alone rather than hidden behind
`sonar.coverage.exclusions`.