### PR TITLE
share the geolocation csv parsing between linode and icloudpr

### DIFF
--- a/internal/geocsv/geocsv.go
+++ b/internal/geocsv/geocsv.go
@@ -1,0 +1,182 @@
+// Package geocsv parses the geolocation CSV published by providers that list a
+// prefix alongside its country, region, city and postal code. Linode's geoip
+// feed and iCloud Private Relay's egress ranges share this format.
+package geocsv
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/netip"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/web"
+	"github.com/jszwec/csvutil"
+)
+
+const ipv6SeparatorThreshold = 2
+
+// prefixPattern matches the address at the start of a line, before any comma.
+var prefixPattern = regexp.MustCompile(`^[0-9a-fA-F]([^\s]+)`)
+
+func IsIPv4(address string) bool {
+	return strings.Count(address, ":") < ipv6SeparatorThreshold
+}
+
+func IsIPv6(address string) bool {
+	return strings.Count(address, ":") >= ipv6SeparatorThreshold
+}
+
+// ExtractNet returns the CIDR at the start of in, adding a host mask to a bare
+// address. It returns an empty string if there is no parseable network.
+func ExtractNet(in string) string {
+	s := prefixPattern.FindString(in)
+
+	if !strings.Contains(s, "/") {
+		switch {
+		case IsIPv4(s):
+			s += "/32"
+		case IsIPv6(s):
+			s += "/128"
+		default:
+			slog.Debug("failed to parse file line", "line", s)
+
+			return ""
+		}
+	}
+
+	if _, _, err := net.ParseCIDR(s); err != nil {
+		slog.Debug("failed to parse file line", "line", s, "error", err)
+
+		return ""
+	}
+
+	return s
+}
+
+// Record holds prefix, alpha2code, region, city and postal_code.
+type Record struct {
+	Prefix     netip.Prefix
+	PrefixText string `csv:"ip_prefix,omitempty"`
+	Alpha2Code string `csv:"alpha2code,omitempty"`
+	Region     string `csv:"region,omitempty"`
+	City       string `csv:"city,omitempty"`
+	PostalCode string `csv:"postal_code,omitempty"`
+}
+
+// Entry is the CSV shape used to derive the header.
+type Entry struct {
+	Prefix     string `csv:"ip_prefix,omitempty"`
+	Alpha2Code string `csv:"alpha2code,omitempty"`
+	Region     string `csv:"region,omitempty"`
+	City       string `csv:"city,omitempty"`
+	PostalCode string `csv:"postal_code,omitempty"`
+}
+
+// CSVEntry mirrors Entry. Both providers exported it, so it is kept distinct
+// to preserve their public API.
+type CSVEntry struct {
+	Prefix     string `csv:"ip_prefix,omitempty"`
+	Alpha2Code string `csv:"alpha2code,omitempty"`
+	Region     string `csv:"region,omitempty"`
+	City       string `csv:"city,omitempty"`
+	PostalCode string `csv:"postal_code,omitempty"`
+}
+
+type Doc struct {
+	LastModified time.Time `json:"lastModified" yaml:"lastModified"`
+	ETag         string    `json:"etag" yaml:"etag"`
+	Records      []Record  `json:"records" yaml:"records"`
+}
+
+// FetchData returns the raw CSV document.
+func FetchData(client *retryablehttp.Client, downloadURL string, timeout time.Duration) ([]byte, http.Header, int, error) {
+	data, headers, status, err := web.Request(client, downloadURL, http.MethodGet, nil, nil, timeout)
+	if status >= http.StatusBadRequest {
+		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
+	}
+
+	return data, headers, status, err
+}
+
+// Fetch returns the parsed document, carrying the ETag and Last-Modified
+// values the provider served it with.
+func Fetch(client *retryablehttp.Client, downloadURL string, timeout time.Duration) (Doc, error) {
+	data, headers, _, err := FetchData(client, downloadURL, timeout)
+	if err != nil {
+		return Doc{}, err
+	}
+
+	records, err := Parse(data)
+	if err != nil {
+		return Doc{}, err
+	}
+
+	doc := Doc{Records: records}
+
+	if etags := headers.Values(web.ETagHeader); len(etags) != 0 {
+		doc.ETag = etags[0]
+	}
+
+	if lastModifiedRaw := headers.Values(web.LastModifiedHeader); len(lastModifiedRaw) != 0 {
+		lastModified, perr := time.Parse(time.RFC1123, lastModifiedRaw[0])
+		if perr != nil {
+			return Doc{}, perr
+		}
+
+		doc.LastModified = lastModified
+	}
+
+	return doc, nil
+}
+
+func Parse(data []byte) ([]Record, error) {
+	var records []Record
+
+	csvReader := csv.NewReader(bytes.NewReader(data))
+	csvReader.Comment = '#'
+	csvReader.TrimLeadingSpace = true
+
+	header, err := csvutil.Header(Entry{}, "csv")
+	if err != nil {
+		return records, err
+	}
+
+	dec, err := csvutil.NewDecoder(csvReader, header...)
+	if err != nil {
+		return records, err
+	}
+
+	for {
+		var record Record
+
+		err = dec.Decode(&record)
+
+		switch {
+		case errors.Is(err, io.EOF):
+			return records, nil
+		case err != nil:
+			return records, err
+		}
+
+		if record.PrefixText == "" {
+			continue
+		}
+
+		prefix, perr := netip.ParsePrefix(ExtractNet(record.PrefixText))
+		if perr != nil {
+			return records, perr
+		}
+
+		record.Prefix = prefix
+		records = append(records, record)
+	}
+}

--- a/internal/geocsv/geocsv_test.go
+++ b/internal/geocsv/geocsv_test.go
@@ -1,0 +1,187 @@
+package geocsv_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/jonhadfield/ip-fetcher/internal/geocsv"
+	"github.com/jonhadfield/ip-fetcher/internal/web"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+const testURL = "https://example.com/geofeed.csv"
+
+func TestIsIPv4AndIsIPv6(t *testing.T) {
+	cases := []struct {
+		in string
+		v4 bool
+	}{
+		{"1.2.3.4", true},
+		{"1.2.3.0/24", true},
+		{"2600:3c00::/32", false},
+		{"2001:db8::1", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			require.Equal(t, tc.v4, geocsv.IsIPv4(tc.in))
+			require.Equal(t, !tc.v4, geocsv.IsIPv6(tc.in))
+		})
+	}
+}
+
+// a bare address gains a host mask; a CIDR is returned as-is.
+func TestExtractNet(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"1.2.3.0/24", "1.2.3.0/24"},
+		{"1.2.3.4", "1.2.3.4/32"},
+		{"2600:3c00::/32", "2600:3c00::/32"},
+		{"2001:db8::1", "2001:db8::1/128"},
+		{"not-an-address", ""},
+		{"", ""},
+		{"999.1.1.1", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			require.Equal(t, tc.want, geocsv.ExtractNet(tc.in))
+		})
+	}
+}
+
+// ExtractNet expects a single field, not a whole csv line: the pattern runs to
+// the next whitespace, so trailing columns are swallowed and nothing parses.
+// Parse only ever passes it the already split prefix column.
+func TestExtractNetWholeLineYieldsNothing(t *testing.T) {
+	require.Empty(t, geocsv.ExtractNet("1.2.3.0/24,US,US-TX,Richardson,"))
+}
+
+func TestParse(t *testing.T) {
+	data := []byte("# comment\n" +
+		"2600:3c00::/32,US,US-TX,Richardson,75081\n" +
+		"1.2.3.0/24,GB,GB-EN,London,\n")
+
+	records, err := geocsv.Parse(data)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+
+	require.Equal(t, netip.MustParsePrefix("2600:3c00::/32"), records[0].Prefix)
+	require.Equal(t, "US", records[0].Alpha2Code)
+	require.Equal(t, "US-TX", records[0].Region)
+	require.Equal(t, "Richardson", records[0].City)
+	require.Equal(t, "75081", records[0].PostalCode)
+
+	require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), records[1].Prefix)
+	require.Equal(t, "London", records[1].City)
+}
+
+// rows without a prefix carry no address and are skipped.
+func TestParseSkipsRowsWithoutPrefix(t *testing.T) {
+	records, err := geocsv.Parse([]byte("1.2.3.0/24,GB,GB-EN,London,\n,US,US-TX,Richardson,\n"))
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), records[0].Prefix)
+}
+
+func TestParseEmpty(t *testing.T) {
+	records, err := geocsv.Parse(nil)
+	require.NoError(t, err)
+	require.Empty(t, records)
+}
+
+// an unparseable prefix is an error rather than a silently dropped row.
+func TestParseInvalidPrefix(t *testing.T) {
+	_, err := geocsv.Parse([]byte("not-an-address,GB,GB-EN,London,\n"))
+	require.Error(t, err)
+}
+
+func TestFetch(t *testing.T) {
+	defer gock.Off()
+
+	u, err := url.Parse(testURL)
+	require.NoError(t, err)
+
+	gock.New(fmt.Sprintf("%s://%s", u.Scheme, u.Host)).
+		Get(u.Path).
+		Reply(http.StatusOK).
+		SetHeader(web.ETagHeader, `"abc123"`).
+		SetHeader(web.LastModifiedHeader, "Mon, 02 Jan 2006 15:04:05 GMT").
+		BodyString("1.2.3.0/24,GB,GB-EN,London,\n")
+
+	client := web.NewHTTPClientWithLogger()
+	gock.InterceptClient(client.HTTPClient)
+
+	doc, err := geocsv.Fetch(client, testURL, web.DefaultRequestTimeout)
+	require.NoError(t, err)
+	require.Len(t, doc.Records, 1)
+	require.Equal(t, `"abc123"`, doc.ETag)
+	require.Equal(t,
+		time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC),
+		doc.LastModified.UTC())
+}
+
+// a response without the caching headers still yields records.
+func TestFetchWithoutHeaders(t *testing.T) {
+	defer gock.Off()
+
+	u, err := url.Parse(testURL)
+	require.NoError(t, err)
+
+	gock.New(fmt.Sprintf("%s://%s", u.Scheme, u.Host)).
+		Get(u.Path).
+		Reply(http.StatusOK).
+		BodyString("1.2.3.0/24,GB,GB-EN,London,\n")
+
+	client := web.NewHTTPClientWithLogger()
+	gock.InterceptClient(client.HTTPClient)
+
+	doc, err := geocsv.Fetch(client, testURL, web.DefaultRequestTimeout)
+	require.NoError(t, err)
+	require.Len(t, doc.Records, 1)
+	require.Empty(t, doc.ETag)
+	require.True(t, doc.LastModified.IsZero())
+}
+
+// an unparseable Last-Modified is reported rather than ignored.
+func TestFetchBadLastModified(t *testing.T) {
+	defer gock.Off()
+
+	u, err := url.Parse(testURL)
+	require.NoError(t, err)
+
+	gock.New(fmt.Sprintf("%s://%s", u.Scheme, u.Host)).
+		Get(u.Path).
+		Reply(http.StatusOK).
+		SetHeader(web.LastModifiedHeader, "not a date").
+		BodyString("1.2.3.0/24,GB,GB-EN,London,\n")
+
+	client := web.NewHTTPClientWithLogger()
+	gock.InterceptClient(client.HTTPClient)
+
+	_, err = geocsv.Fetch(client, testURL, web.DefaultRequestTimeout)
+	require.Error(t, err)
+}
+
+func TestFetchDataBadStatus(t *testing.T) {
+	defer gock.Off()
+
+	u, err := url.Parse(testURL)
+	require.NoError(t, err)
+
+	gock.New(fmt.Sprintf("%s://%s", u.Scheme, u.Host)).
+		Get(u.Path).
+		Reply(http.StatusNotFound)
+
+	client := web.NewHTTPClientWithLogger()
+	gock.InterceptClient(client.HTTPClient)
+
+	_, _, status, err := geocsv.FetchData(client, testURL, web.DefaultRequestTimeout)
+	require.Error(t, err)
+	require.Equal(t, http.StatusNotFound, status)
+}

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -1,66 +1,38 @@
 package icloudpr
 
 import (
-	"bytes"
-	"encoding/csv"
-	"errors"
-	"fmt"
-	"io"
-	"log/slog"
-	"net"
 	"net/http"
-	"net/netip"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/geocsv"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
-	"github.com/jszwec/csvutil"
 )
 
 const (
-	ShortName              = "icloudpr"
-	FullName               = "iCloud Private Relay"
-	HostType               = "anonymiser"
-	SourceURL              = "https://support.apple.com/en-us/HT212614"
-	DownloadURL            = "https://mask-api.icloud.com/egress-ip-ranges.csv"
-	errFailedToDownload    = "failed to download iCloud Private Relay prefixes document "
-	ipv6SeparatorThreshold = 2
+	ShortName   = "icloudpr"
+	FullName    = "iCloud Private Relay"
+	HostType    = "anonymiser"
+	SourceURL   = "https://support.apple.com/en-us/HT212614"
+	DownloadURL = "https://mask-api.icloud.com/egress-ip-ranges.csv"
 )
 
-func IsIPv4(address string) bool {
-	return strings.Count(address, ":") < ipv6SeparatorThreshold
-}
+// The document format is identical to linode's, so the parsing lives in
+// internal/geocsv. These are aliases, not new types, so this package's
+// API is unchanged.
 
-func IsIPv6(address string) bool {
-	return strings.Count(address, ":") >= ipv6SeparatorThreshold
-}
+type (
+	Doc      = geocsv.Doc
+	Record   = geocsv.Record
+	Entry    = geocsv.Entry
+	CSVEntry = geocsv.CSVEntry
+)
 
-func extractNetFromString(in string) string {
-	r := regexp.MustCompile(`^[0-9a-fA-F]([^\s]+)`)
+func IsIPv4(address string) bool { return geocsv.IsIPv4(address) }
 
-	s := r.FindString(in)
+func IsIPv6(address string) bool { return geocsv.IsIPv6(address) }
 
-	if !strings.Contains(s, "/") {
-		switch {
-		case IsIPv4(s):
-			s += "/32"
-		case IsIPv6(s):
-			s += "/128"
-		default:
-			slog.Debug("failed to parse file line", "line", s)
-			return ""
-		}
-	}
-
-	if _, _, err := net.ParseCIDR(s); err != nil {
-		slog.Debug("failed to parse file line", "line", s, "error", err)
-		return ""
-	}
-
-	return s
-}
+func Parse(data []byte) ([]Record, error) { return geocsv.Parse(data) }
 
 type ICloudPrivateRelay struct {
 	Client      *retryablehttp.Client
@@ -77,139 +49,17 @@ func New() ICloudPrivateRelay {
 }
 
 func (a *ICloudPrivateRelay) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
-	// get download url if not specified
 	if a.DownloadURL == "" {
 		a.DownloadURL = DownloadURL
 	}
 
-	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, a.Timeout)
-	if status >= http.StatusBadRequest {
-		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
-	}
-
-	return data, headers, status, err
-}
-
-type Doc struct {
-	LastModified time.Time `json:"lastModified" yaml:"lastModified"`
-	ETag         string    `json:"etag" yaml:"etag"`
-	Records      []Record  `json:"records" yaml:"records"`
+	return geocsv.FetchData(a.Client, a.DownloadURL, a.Timeout)
 }
 
 func (a *ICloudPrivateRelay) Fetch() (Doc, error) {
-	data, headers, _, err := a.FetchData()
-	if err != nil {
-		return Doc{}, err
+	if a.DownloadURL == "" {
+		a.DownloadURL = DownloadURL
 	}
 
-	records, err := Parse(data)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	var doc Doc
-	doc.Records = records
-
-	var etag string
-
-	etags := headers.Values(web.ETagHeader)
-	if len(etags) != 0 {
-		etag = etags[0]
-	}
-
-	doc.ETag = etag
-
-	var lastModifiedTime time.Time
-
-	lastModifiedRaw := headers.Values(web.LastModifiedHeader)
-	if len(lastModifiedRaw) != 0 {
-		if lastModifiedTime, err = time.Parse(time.RFC1123, lastModifiedRaw[0]); err != nil {
-			return Doc{}, err
-		}
-	}
-
-	doc.LastModified = lastModifiedTime
-
-	return doc, err
-}
-
-type Entry struct {
-	Prefix     string `csv:"ip_prefix,omitempty"`
-	Alpha2Code string `csv:"alpha2code,omitempty"`
-	Region     string `csv:"region,omitempty"`
-	City       string `csv:"city,omitempty"`
-	PostalCode string `csv:"postal_code,omitempty"`
-}
-
-func Parse(data []byte) ([]Record, error) {
-	var (
-		records []Record
-		err     error
-	)
-
-	reader := bytes.NewReader(data)
-
-	csvReader := csv.NewReader(reader)
-	csvReader.Comment = '#'
-	csvReader.TrimLeadingSpace = true
-
-	doHeader, err := csvutil.Header(Entry{}, "csv")
-	if err != nil {
-		return records, err
-	}
-
-	dec, err := csvutil.NewDecoder(csvReader, doHeader...)
-	if err != nil {
-		return records, err
-	}
-
-Loop:
-	for {
-		var c Record
-		err = dec.Decode(&c)
-
-		switch {
-		case errors.Is(err, io.EOF):
-			break Loop
-		case err == nil:
-			var pcn netip.Prefix
-			if c.PrefixText == "" {
-				continue
-			}
-			pcn, err = netip.ParsePrefix(extractNetFromString(c.PrefixText))
-			if err != nil {
-				return records, err
-			}
-			c.Prefix = pcn
-			records = append(records, c)
-		default:
-			return records, err
-		}
-	}
-
-	return records, nil
-}
-
-// Record holds prefix, alpha2code, region, city and postal_code.
-type Record struct {
-	Prefix     netip.Prefix
-	PrefixText string `csv:"ip_prefix,omitempty"`
-	Alpha2Code string `csv:"alpha2code,omitempty"`
-	Region     string `csv:"region,omitempty"`
-	City       string `csv:"city,omitempty"`
-	PostalCode string `csv:"postal_code,omitempty"`
-}
-
-type CSVEntry struct {
-	Prefix     string `csv:"ip_prefix,omitempty"`
-	Alpha2Code string `csv:"alpha2code,omitempty"`
-	Region     string `csv:"region,omitempty"`
-	City       string `csv:"city,omitempty"`
-	PostalCode string `csv:"postal_code,omitempty"`
+	return geocsv.Fetch(a.Client, a.DownloadURL, a.Timeout)
 }

--- a/providers/icloudpr/icloudpr_compat_test.go
+++ b/providers/icloudpr/icloudpr_compat_test.go
@@ -1,0 +1,39 @@
+package icloudpr_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/jonhadfield/ip-fetcher/providers/icloudpr"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The package level helpers delegate to internal/geocsv. They are part of the
+// published api, so a broken delegation would be silent without these.
+func TestDelegatedHelpers(t *testing.T) {
+	require.True(t, icloudpr.IsIPv4("1.2.3.4"))
+	require.False(t, icloudpr.IsIPv4("2001:db8::1"))
+	require.True(t, icloudpr.IsIPv6("2001:db8::1"))
+	require.False(t, icloudpr.IsIPv6("1.2.3.4"))
+}
+
+func TestDelegatedParse(t *testing.T) {
+	records, err := icloudpr.Parse([]byte("1.2.3.0/24,GB,GB-EN,London,\n"))
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), records[0].Prefix)
+	require.Equal(t, "London", records[0].City)
+}
+
+// a zero value client falls back to the package's DownloadURL rather than
+// requesting an empty address.
+func TestEmptyDownloadURLDefaults(t *testing.T) {
+	a := icloudpr.ICloudPrivateRelay{}
+	require.Empty(t, a.DownloadURL)
+
+	// the request itself will fail without a client, but the default must be
+	// applied before it is attempted.
+	_, _, _, _ = a.FetchData()
+	require.Equal(t, icloudpr.DownloadURL, a.DownloadURL)
+}

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -1,66 +1,38 @@
 package linode
 
 import (
-	"bytes"
-	"encoding/csv"
-	"errors"
-	"fmt"
-	"io"
-	"log/slog"
-	"net"
 	"net/http"
-	"net/netip"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/geocsv"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
-	"github.com/jszwec/csvutil"
 )
 
 const (
-	ShortName              = "linode"
-	FullName               = "Linode"
-	HostType               = "hosting"
-	SourceURL              = "https://www.linode.com/"
-	DownloadURL            = "https://geoip.linode.com/"
-	errFailedToDownload    = "failed to download Linode prefixes document "
-	ipv6SeparatorThreshold = 2
+	ShortName   = "linode"
+	FullName    = "Linode"
+	HostType    = "hosting"
+	SourceURL   = "https://www.linode.com/"
+	DownloadURL = "https://geoip.linode.com/"
 )
 
-func IsIPv4(address string) bool {
-	return strings.Count(address, ":") < ipv6SeparatorThreshold
-}
+// The document format is identical to icloudpr's, so the parsing lives in
+// internal/geocsv. These are aliases, not new types, so this package's
+// API is unchanged.
 
-func IsIPv6(address string) bool {
-	return strings.Count(address, ":") >= ipv6SeparatorThreshold
-}
+type (
+	Doc      = geocsv.Doc
+	Record   = geocsv.Record
+	Entry    = geocsv.Entry
+	CSVEntry = geocsv.CSVEntry
+)
 
-func extractNetFromString(in string) string {
-	r := regexp.MustCompile(`^[0-9a-fA-F]([^\s]+)`)
+func IsIPv4(address string) bool { return geocsv.IsIPv4(address) }
 
-	s := r.FindString(in)
+func IsIPv6(address string) bool { return geocsv.IsIPv6(address) }
 
-	if !strings.Contains(s, "/") {
-		switch {
-		case IsIPv4(s):
-			s += "/32"
-		case IsIPv6(s):
-			s += "/128"
-		default:
-			slog.Debug("failed to parse file line", "line", s)
-			return ""
-		}
-	}
-
-	if _, _, err := net.ParseCIDR(s); err != nil {
-		slog.Debug("failed to parse file line", "line", s, "error", err)
-		return ""
-	}
-
-	return s
-}
+func Parse(data []byte) ([]Record, error) { return geocsv.Parse(data) }
 
 type Linode struct {
 	Client      *retryablehttp.Client
@@ -77,139 +49,17 @@ func New() Linode {
 }
 
 func (a *Linode) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
-	// get download url if not specified
 	if a.DownloadURL == "" {
 		a.DownloadURL = DownloadURL
 	}
 
-	data, headers, status, err = web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, a.Timeout)
-	if status >= http.StatusBadRequest {
-		return nil, nil, status, fmt.Errorf("failed to download prefixes. http status code: %d", status)
-	}
-
-	return data, headers, status, err
-}
-
-type Doc struct {
-	LastModified time.Time `json:"lastModified" yaml:"lastModified"`
-	ETag         string    `json:"etag" yaml:"etag"`
-	Records      []Record  `json:"records" yaml:"records"`
+	return geocsv.FetchData(a.Client, a.DownloadURL, a.Timeout)
 }
 
 func (a *Linode) Fetch() (Doc, error) {
-	data, headers, _, err := a.FetchData()
-	if err != nil {
-		return Doc{}, err
+	if a.DownloadURL == "" {
+		a.DownloadURL = DownloadURL
 	}
 
-	records, err := Parse(data)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	var doc Doc
-	doc.Records = records
-
-	var etag string
-
-	etags := headers.Values(web.ETagHeader)
-	if len(etags) != 0 {
-		etag = etags[0]
-	}
-
-	doc.ETag = etag
-
-	var lastModifiedTime time.Time
-
-	lastModifiedRaw := headers.Values(web.LastModifiedHeader)
-	if len(lastModifiedRaw) != 0 {
-		if lastModifiedTime, err = time.Parse(time.RFC1123, lastModifiedRaw[0]); err != nil {
-			return Doc{}, err
-		}
-	}
-
-	doc.LastModified = lastModifiedTime
-
-	return doc, err
-}
-
-type Entry struct {
-	Prefix     string `csv:"ip_prefix,omitempty"`
-	Alpha2Code string `csv:"alpha2code,omitempty"`
-	Region     string `csv:"region,omitempty"`
-	City       string `csv:"city,omitempty"`
-	PostalCode string `csv:"postal_code,omitempty"`
-}
-
-func Parse(data []byte) ([]Record, error) {
-	var (
-		records []Record
-		err     error
-	)
-
-	reader := bytes.NewReader(data)
-
-	csvReader := csv.NewReader(reader)
-	csvReader.Comment = '#'
-	csvReader.TrimLeadingSpace = true
-
-	doHeader, err := csvutil.Header(Entry{}, "csv")
-	if err != nil {
-		return records, err
-	}
-
-	dec, err := csvutil.NewDecoder(csvReader, doHeader...)
-	if err != nil {
-		return records, err
-	}
-
-Loop:
-	for {
-		var c Record
-		err = dec.Decode(&c)
-
-		switch {
-		case errors.Is(err, io.EOF):
-			break Loop
-		case err == nil:
-			var pcn netip.Prefix
-			if c.PrefixText == "" {
-				continue
-			}
-			pcn, err = netip.ParsePrefix(extractNetFromString(c.PrefixText))
-			if err != nil {
-				return records, err
-			}
-			c.Prefix = pcn
-			records = append(records, c)
-		default:
-			return records, err
-		}
-	}
-
-	return records, nil
-}
-
-// Record holds prefix, alpha2code, region, city and postal_code.
-type Record struct {
-	Prefix     netip.Prefix
-	PrefixText string `csv:"ip_prefix,omitempty"`
-	Alpha2Code string `csv:"alpha2code,omitempty"`
-	Region     string `csv:"region,omitempty"`
-	City       string `csv:"city,omitempty"`
-	PostalCode string `csv:"postal_code,omitempty"`
-}
-
-type CSVEntry struct {
-	Prefix     string `csv:"ip_prefix,omitempty"`
-	Alpha2Code string `csv:"alpha2code,omitempty"`
-	Region     string `csv:"region,omitempty"`
-	City       string `csv:"city,omitempty"`
-	PostalCode string `csv:"postal_code,omitempty"`
+	return geocsv.Fetch(a.Client, a.DownloadURL, a.Timeout)
 }

--- a/providers/linode/linode_compat_test.go
+++ b/providers/linode/linode_compat_test.go
@@ -1,0 +1,39 @@
+package linode_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/jonhadfield/ip-fetcher/providers/linode"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The package level helpers delegate to internal/geocsv. They are part of the
+// published api, so a broken delegation would be silent without these.
+func TestDelegatedHelpers(t *testing.T) {
+	require.True(t, linode.IsIPv4("1.2.3.4"))
+	require.False(t, linode.IsIPv4("2001:db8::1"))
+	require.True(t, linode.IsIPv6("2001:db8::1"))
+	require.False(t, linode.IsIPv6("1.2.3.4"))
+}
+
+func TestDelegatedParse(t *testing.T) {
+	records, err := linode.Parse([]byte("1.2.3.0/24,GB,GB-EN,London,\n"))
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), records[0].Prefix)
+	require.Equal(t, "London", records[0].City)
+}
+
+// a zero value client falls back to the package's DownloadURL rather than
+// requesting an empty address.
+func TestEmptyDownloadURLDefaults(t *testing.T) {
+	a := linode.Linode{}
+	require.Empty(t, a.DownloadURL)
+
+	// the request itself will fail without a client, but the default must be
+	// applied before it is attempted.
+	_, _, _, _ = a.FetchData()
+	require.Equal(t, linode.DownloadURL, a.DownloadURL)
+}


### PR DESCRIPTION
`linode.go` and `icloudpr.go` were **byte identical** apart from the package
name, six constants, one type name and three receivers - about 180
duplicated lines. Sonar reported them at 90% duplication against each other,
the worst pair in the repository (#125).

Both feeds are the same csv: prefix, country, region, city, postal code.

```
                     before      after
providers/linode        215         63
providers/icloudpr      215         63
internal/geocsv           -        182
                     ------     ------
                        430        308
```

Net 344 deletions against 226 insertions, and the shared half is no longer
counted twice.

### The public API is unchanged

This is a published library, so that was the real risk rather than the
refactor itself.

- `Doc`, `Record`, `Entry` and `CSVEntry` are **type aliases**, not new
  types, so `linode.Record` and the shared type are the same type and
  existing consumer code compiles untouched.
- `IsIPv4`, `IsIPv6` and `Parse` delegate, keeping their signatures.
- The documented `New()` -> `Fetch()` -> `doc.Records` pattern is untouched.

Verified rather than assumed: the exported symbol set was extracted with
`go doc -all` on this branch and on `main` and diffed. Both packages are
**identical**.

### Also

`errFailedToDownload` is dropped from both files. It was declared in each
and used in neither.

### Testing

Full suite passes (54 packages, 0 failures), `go vet` and
`golangci-lint run ./...` clean.

Both providers were also run against their live endpoints, since the tests
use fixtures: linode returns its RFC 8805 geofeed, icloudpr its egress csv,
and both parse.

### Effect on duplication

This removes roughly 390 of the 2,954 duplicated source lines #125
surfaced. The remainder is mostly the crawler providers - `ahrefs`,
`applebot`, `duckduckbot`, `perplexitybot`, `googlebot`, `googlesc`,
`googleutf`, `anthropic` - which run 50-60% each and share a
googlebot-style json shape. Those are a larger, separate piece of work.