### PR TITLE
share the crawler prefix parsing across the eight bot providers

### DIFF
--- a/internal/botprefix/botprefix.go
+++ b/internal/botprefix/botprefix.go
@@ -1,0 +1,143 @@
+// Package botprefix parses the crawler prefix document that Google publishes
+// for its bots and that several other operators have adopted: a creationTime
+// and a prefixes array whose entries carry either an ipv4Prefix or an
+// ipv6Prefix.
+package botprefix
+
+import (
+	"encoding/json"
+	"net/netip"
+	"time"
+)
+
+// DefaultTimeFormat is the creationTime layout these feeds use.
+const DefaultTimeFormat = "2006-01-02T15:04:05.999999"
+
+type RawIPv4Entry struct {
+	IPv4Prefix string `json:"ipv4Prefix"`
+}
+
+type RawIPv6Entry struct {
+	IPv6Prefix string `json:"ipv6Prefix"`
+}
+
+type RawDoc struct {
+	CreationTime  string            `json:"creationTime"`
+	LastRequested time.Time         `json:"-" yaml:"-"`
+	Entries       []json.RawMessage `json:"prefixes"`
+}
+
+type IPv4Entry struct {
+	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
+}
+
+type IPv6Entry struct {
+	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
+}
+
+type Doc struct {
+	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
+	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
+	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+}
+
+// Options covers the only way these feeds differ: how they treat creationTime.
+type Options struct {
+	// TimeFormats are tried in order. Empty means DefaultTimeFormat.
+	TimeFormats []string
+
+	// RequireCreationTime makes an absent creationTime an error. Google's feeds
+	// always carry one; several of the others omit it.
+	RequireCreationTime bool
+}
+
+func Parse(data []byte, opts Options) (Doc, error) {
+	var rawDoc RawDoc
+
+	if err := json.Unmarshal(data, &rawDoc); err != nil {
+		return Doc{}, err
+	}
+
+	ipv4, ipv6, err := castEntries(rawDoc.Entries)
+	if err != nil {
+		return Doc{}, err
+	}
+
+	doc := Doc{IPv4Prefixes: ipv4, IPv6Prefixes: ipv6}
+
+	if rawDoc.CreationTime == "" && !opts.RequireCreationTime {
+		return doc, nil
+	}
+
+	creationTime, err := parseCreationTime(rawDoc.CreationTime, opts.TimeFormats)
+	if err != nil {
+		return Doc{}, err
+	}
+
+	doc.CreationTime = creationTime
+
+	return doc, nil
+}
+
+// parseCreationTime tries each format in turn, reporting the last failure.
+func parseCreationTime(in string, formats []string) (time.Time, error) {
+	if len(formats) == 0 {
+		formats = []string{DefaultTimeFormat}
+	}
+
+	var lastErr error
+
+	for _, format := range formats {
+		creationTime, err := time.Parse(format, in)
+		if err == nil {
+			return creationTime, nil
+		}
+
+		lastErr = err
+	}
+
+	return time.Time{}, lastErr
+}
+
+// castEntries sorts the prefix entries by address family. An entry carries
+// either an ipv4Prefix or an ipv6Prefix, so each is tried in turn.
+func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
+	var (
+		ipv4 []IPv4Entry
+		ipv6 []IPv6Entry
+	)
+
+	for _, pr := range prefixes {
+		var (
+			ipv4entry RawIPv4Entry
+			ipv6entry RawIPv6Entry
+		)
+
+		// try 4
+		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
+			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
+			if parseError == nil {
+				ipv4 = append(ipv4, IPv4Entry{IPv4Prefix: ipv4Prefix})
+
+				continue
+			}
+		}
+
+		// try 6
+		ipv6Err := json.Unmarshal(pr, &ipv6entry)
+		if ipv6Err == nil {
+			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
+			if parseError != nil {
+				return ipv4, ipv6, parseError
+			}
+
+			ipv6 = append(ipv6, IPv6Entry{IPv6Prefix: ipv6Prefix})
+
+			continue
+		}
+
+		return ipv4, ipv6, ipv6Err
+	}
+
+	return ipv4, ipv6, nil
+}

--- a/internal/botprefix/botprefix_test.go
+++ b/internal/botprefix/botprefix_test.go
@@ -1,0 +1,92 @@
+package botprefix_test
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
+
+	"github.com/stretchr/testify/require"
+)
+
+const bothFamilies = `{"creationTime":"2026-08-01T10:00:00.000000","prefixes":[` +
+	`{"ipv4Prefix":"54.36.148.0/23"},{"ipv6Prefix":"2001:db8::/32"}]}`
+
+func TestParse(t *testing.T) {
+	doc, err := botprefix.Parse([]byte(bothFamilies), botprefix.Options{})
+	require.NoError(t, err)
+	require.Equal(t, []botprefix.IPv4Entry{
+		{IPv4Prefix: netip.MustParsePrefix("54.36.148.0/23")},
+	}, doc.IPv4Prefixes)
+	require.Equal(t, []botprefix.IPv6Entry{
+		{IPv6Prefix: netip.MustParsePrefix("2001:db8::/32")},
+	}, doc.IPv6Prefixes)
+	require.Equal(t,
+		time.Date(2026, time.August, 1, 10, 0, 0, 0, time.UTC),
+		doc.CreationTime)
+}
+
+// The three feeds differ only in how they treat creationTime, so each policy
+// is pinned here.
+func TestCreationTimePolicies(t *testing.T) {
+	noTime := `{"prefixes":[{"ipv4Prefix":"1.2.3.0/24"}]}`
+
+	t.Run("optional accepts a feed without creationTime", func(t *testing.T) {
+		doc, err := botprefix.Parse([]byte(noTime), botprefix.Options{})
+		require.NoError(t, err)
+		require.True(t, doc.CreationTime.IsZero())
+		require.Len(t, doc.IPv4Prefixes, 1)
+	})
+
+	t.Run("required rejects a feed without creationTime", func(t *testing.T) {
+		_, err := botprefix.Parse([]byte(noTime), botprefix.Options{RequireCreationTime: true})
+		require.Error(t, err)
+	})
+
+	t.Run("rfc3339 needs the format listed", func(t *testing.T) {
+		rfc := `{"creationTime":"2026-08-01T10:00:00Z","prefixes":[]}`
+
+		_, err := botprefix.Parse([]byte(rfc), botprefix.Options{})
+		require.Error(t, err)
+
+		doc, err := botprefix.Parse([]byte(rfc), botprefix.Options{
+			TimeFormats: []string{time.RFC3339, botprefix.DefaultTimeFormat},
+		})
+		require.NoError(t, err)
+		require.Equal(t, time.Date(2026, time.August, 1, 10, 0, 0, 0, time.UTC), doc.CreationTime.UTC())
+	})
+
+	t.Run("later formats are tried after earlier ones fail", func(t *testing.T) {
+		doc, err := botprefix.Parse([]byte(bothFamilies), botprefix.Options{
+			TimeFormats: []string{time.RFC3339, botprefix.DefaultTimeFormat},
+		})
+		require.NoError(t, err)
+		require.False(t, doc.CreationTime.IsZero())
+	})
+}
+
+func TestParseEmptyPrefixes(t *testing.T) {
+	doc, err := botprefix.Parse([]byte(`{"creationTime":"2026-08-01T10:00:00.000000","prefixes":[]}`), botprefix.Options{})
+	require.NoError(t, err)
+	require.Empty(t, doc.IPv4Prefixes)
+	require.Empty(t, doc.IPv6Prefixes)
+}
+
+func TestParseInvalidJSON(t *testing.T) {
+	_, err := botprefix.Parse([]byte("not json"), botprefix.Options{})
+	require.Error(t, err)
+}
+
+// an unparseable ipv6 prefix is reported rather than skipped.
+func TestParseInvalidIPv6Prefix(t *testing.T) {
+	_, err := botprefix.Parse([]byte(`{"prefixes":[{"ipv6Prefix":"nonsense"}]}`), botprefix.Options{})
+	require.Error(t, err)
+}
+
+// an unparseable creationTime is an error even when it is optional, since the
+// field is present.
+func TestParseInvalidCreationTime(t *testing.T) {
+	_, err := botprefix.Parse([]byte(`{"creationTime":"nonsense","prefixes":[]}`), botprefix.Options{})
+	require.Error(t, err)
+}

--- a/providers/ahrefs/ahrefs.go
+++ b/providers/ahrefs/ahrefs.go
@@ -1,23 +1,40 @@
 package ahrefs
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
 const (
-	ShortName                = "ahrefs"
-	FullName                 = "AhrefsBot"
-	HostType                 = "crawlers"
-	SourceURL                = "https://api.ahrefs.com/v3/public/crawler-ip-ranges"
-	DownloadURL              = "https://api.ahrefs.com/v3/public/crawler-ip-ranges"
-	downloadedFileTimeFormat = "2006-01-02T15:04:05.999999"
+	ShortName   = "ahrefs"
+	FullName    = "AhrefsBot"
+	HostType    = "crawlers"
+	SourceURL   = "https://api.ahrefs.com/v3/public/crawler-ip-ranges"
+	DownloadURL = "https://api.ahrefs.com/v3/public/crawler-ip-ranges"
 )
+
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Ahrefs struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
+}
 
 func New() Ahrefs {
 	return Ahrefs{
@@ -27,37 +44,12 @@ func New() Ahrefs {
 	}
 }
 
-type Ahrefs struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (a *Ahrefs) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
 	if a.DownloadURL == "" {
 		a.DownloadURL = DownloadURL
 	}
-	data, headers, status, err = web.Request(
-		a.Client,
-		a.DownloadURL,
-		http.MethodGet,
-		nil,
-		nil,
-		a.Timeout,
-	)
-	return data, headers, status, err
+
+	return web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, a.Timeout)
 }
 
 func (a *Ahrefs) Fetch() (Doc, error) {
@@ -69,97 +61,8 @@ func (a *Ahrefs) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. creationTime is not always present in the
+// ahrefs document, so it is optional.
 func ProcessData(data []byte) (Doc, error) {
-	var (
-		doc    Doc
-		rawDoc RawDoc
-	)
-	err := json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	// creationTime is not always present in the ahrefs feed, so treat it as optional.
-	if rawDoc.CreationTime != "" {
-		var ct time.Time
-
-		ct, err = time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
-		if err != nil {
-			return Doc{}, err
-		}
-
-		doc.CreationTime = ct
-	}
-
-	return doc, nil
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var (
-		ipv4 []IPv4Entry
-		ipv6 []IPv6Entry
-	)
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{})
 }

--- a/providers/ahrefs/ahrefs_test.go
+++ b/providers/ahrefs/ahrefs_test.go
@@ -30,7 +30,7 @@ func TestFetch(t *testing.T) {
 	doc, err := ac.Fetch()
 	require.NoError(t, err)
 	require.NotEmpty(t, doc.IPv4Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, ahrefs.IPv4Entry{netip.MustParsePrefix("54.36.148.0/23")})
+	require.Contains(t, doc.IPv4Prefixes, ahrefs.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("54.36.148.0/23")})
 	require.Empty(t, doc.IPv6Prefixes)
 	require.True(t, doc.CreationTime.IsZero())
 }
@@ -42,7 +42,7 @@ func TestProcessData(t *testing.T) {
 	doc, err := ahrefs.ProcessData(data)
 	require.NoError(t, err)
 	require.Len(t, doc.IPv4Prefixes, 4)
-	require.Contains(t, doc.IPv4Prefixes, ahrefs.IPv4Entry{netip.MustParsePrefix("198.244.240.0/24")})
+	require.Contains(t, doc.IPv4Prefixes, ahrefs.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("198.244.240.0/24")})
 	require.Empty(t, doc.IPv6Prefixes)
 	require.True(t, doc.CreationTime.IsZero())
 }
@@ -52,8 +52,8 @@ func TestProcessDataWithCreationTime(t *testing.T) {
 
 	doc, err := ahrefs.ProcessData(data)
 	require.NoError(t, err)
-	require.Contains(t, doc.IPv4Prefixes, ahrefs.IPv4Entry{netip.MustParsePrefix("5.39.1.224/27")})
-	require.Contains(t, doc.IPv6Prefixes, ahrefs.IPv6Entry{netip.MustParsePrefix("2001:db8::/32")})
+	require.Contains(t, doc.IPv4Prefixes, ahrefs.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("5.39.1.224/27")})
+	require.Contains(t, doc.IPv6Prefixes, ahrefs.IPv6Entry{IPv6Prefix: netip.MustParsePrefix("2001:db8::/32")})
 	require.False(t, doc.CreationTime.IsZero())
 	require.Equal(t, 2026, doc.CreationTime.Year())
 }

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -1,12 +1,11 @@
 package anthropic
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
@@ -18,11 +17,23 @@ const (
 	DownloadURL = "https://claude.com/crawling/bots.json"
 )
 
-// creationTime is published as RFC3339, but sibling crawler feeds use a
-// fractional seconds variant, so both are accepted.
-var creationTimeFormats = []string{
-	time.RFC3339,
-	"2006-01-02T15:04:05.999999",
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Anthropic struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
 }
 
 func New() Anthropic {
@@ -33,31 +44,12 @@ func New() Anthropic {
 	}
 }
 
-type Anthropic struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (a *Anthropic) FetchData() ([]byte, http.Header, int, error) {
 	if a.DownloadURL == "" {
 		a.DownloadURL = DownloadURL
 	}
 
-	return web.Request(
-		a.Client,
-		a.DownloadURL,
-		http.MethodGet,
-		nil,
-		nil,
-		a.Timeout,
-	)
+	return web.Request(a.Client, a.DownloadURL, http.MethodGet, nil, nil, a.Timeout)
 }
 
 func (a *Anthropic) Fetch() (Doc, error) {
@@ -69,114 +61,9 @@ func (a *Anthropic) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. creationTime is published as RFC3339 here,
+// while sibling feeds use a fractional seconds variant, so both are accepted
+// and it is optional.
 func ProcessData(data []byte) (Doc, error) {
-	var (
-		doc    Doc
-		rawDoc RawDoc
-	)
-
-	err := json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	// creationTime may be absent from the feed, so treat it as optional.
-	if rawDoc.CreationTime != "" {
-		var ct time.Time
-
-		ct, err = parseCreationTime(rawDoc.CreationTime)
-		if err != nil {
-			return Doc{}, err
-		}
-
-		doc.CreationTime = ct
-	}
-
-	return doc, nil
-}
-
-func parseCreationTime(in string) (time.Time, error) {
-	var lastErr error
-
-	for _, format := range creationTimeFormats {
-		ct, err := time.Parse(format, in)
-		if err == nil {
-			return ct, nil
-		}
-
-		lastErr = err
-	}
-
-	return time.Time{}, lastErr
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var (
-		ipv4 []IPv4Entry
-		ipv6 []IPv6Entry
-	)
-
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{TimeFormats: []string{time.RFC3339, botprefix.DefaultTimeFormat}})
 }

--- a/providers/applebot/applebot.go
+++ b/providers/applebot/applebot.go
@@ -1,23 +1,40 @@
 package applebot
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
 const (
-	ShortName                = "applebot"
-	FullName                 = "Applebot"
-	HostType                 = "crawlers"
-	SourceURL                = "https://support.apple.com/en-us/119829"
-	DownloadURL              = "https://search.developer.apple.com/applebot.json"
-	downloadedFileTimeFormat = "2006-01-02T15:04:05.999999"
+	ShortName   = "applebot"
+	FullName    = "Applebot"
+	HostType    = "crawlers"
+	SourceURL   = "https://support.apple.com/en-us/119829"
+	DownloadURL = "https://search.developer.apple.com/applebot.json"
 )
+
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Applebot struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
+}
 
 func New() Applebot {
 	return Applebot{
@@ -27,37 +44,12 @@ func New() Applebot {
 	}
 }
 
-type Applebot struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (ab *Applebot) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
 	if ab.DownloadURL == "" {
 		ab.DownloadURL = DownloadURL
 	}
-	data, headers, status, err = web.Request(
-		ab.Client,
-		ab.DownloadURL,
-		http.MethodGet,
-		nil,
-		nil,
-		ab.Timeout,
-	)
-	return data, headers, status, err
+
+	return web.Request(ab.Client, ab.DownloadURL, http.MethodGet, nil, nil, ab.Timeout)
 }
 
 func (ab *Applebot) Fetch() (Doc, error) {
@@ -69,97 +61,7 @@ func (ab *Applebot) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. creationTime may be absent, so it is optional.
 func ProcessData(data []byte) (Doc, error) {
-	var (
-		doc    Doc
-		rawDoc RawDoc
-	)
-	err := json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	// creationTime may be absent from the feed, so treat it as optional.
-	if rawDoc.CreationTime != "" {
-		var ct time.Time
-
-		ct, err = time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
-		if err != nil {
-			return Doc{}, err
-		}
-
-		doc.CreationTime = ct
-	}
-
-	return doc, nil
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var (
-		ipv4 []IPv4Entry
-		ipv6 []IPv6Entry
-	)
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{})
 }

--- a/providers/applebot/applebot_test.go
+++ b/providers/applebot/applebot_test.go
@@ -30,8 +30,8 @@ func TestFetch(t *testing.T) {
 	doc, err := ac.Fetch()
 	require.NoError(t, err)
 	require.NotEmpty(t, doc.IPv4Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, applebot.IPv4Entry{netip.MustParsePrefix("17.241.208.160/27")})
-	require.Contains(t, doc.IPv4Prefixes, applebot.IPv4Entry{netip.MustParsePrefix("17.22.237.0/24")})
+	require.Contains(t, doc.IPv4Prefixes, applebot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("17.241.208.160/27")})
+	require.Contains(t, doc.IPv4Prefixes, applebot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("17.22.237.0/24")})
 	require.Empty(t, doc.IPv6Prefixes)
 }
 
@@ -42,7 +42,7 @@ func TestProcessData(t *testing.T) {
 	doc, err := applebot.ProcessData(data)
 	require.NoError(t, err)
 	require.Len(t, doc.IPv4Prefixes, 4)
-	require.Contains(t, doc.IPv4Prefixes, applebot.IPv4Entry{netip.MustParsePrefix("17.246.15.0/24")})
+	require.Contains(t, doc.IPv4Prefixes, applebot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("17.246.15.0/24")})
 	require.Empty(t, doc.IPv6Prefixes)
 	require.Equal(t, 2023, doc.CreationTime.Year())
 }

--- a/providers/duckduckbot/duckduckbot.go
+++ b/providers/duckduckbot/duckduckbot.go
@@ -1,23 +1,40 @@
 package duckduckbot
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
 const (
-	ShortName                = "duckduckbot"
-	FullName                 = "DuckDuckBot"
-	HostType                 = "crawlers"
-	SourceURL                = "https://duckduckgo.com/duckduckbot.json"
-	DownloadURL              = "https://duckduckgo.com/duckduckbot.json"
-	downloadedFileTimeFormat = "2006-01-02T15:04:05.999999"
+	ShortName   = "duckduckbot"
+	FullName    = "DuckDuckBot"
+	HostType    = "crawlers"
+	SourceURL   = "https://duckduckgo.com/duckduckbot.json"
+	DownloadURL = "https://duckduckgo.com/duckduckbot.json"
 )
+
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Duckduckbot struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
+}
 
 func New() Duckduckbot {
 	return Duckduckbot{
@@ -27,37 +44,12 @@ func New() Duckduckbot {
 	}
 }
 
-type Duckduckbot struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (db *Duckduckbot) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
 	if db.DownloadURL == "" {
 		db.DownloadURL = DownloadURL
 	}
-	data, headers, status, err = web.Request(
-		db.Client,
-		db.DownloadURL,
-		http.MethodGet,
-		nil,
-		nil,
-		db.Timeout,
-	)
-	return data, headers, status, err
+
+	return web.Request(db.Client, db.DownloadURL, http.MethodGet, nil, nil, db.Timeout)
 }
 
 func (db *Duckduckbot) Fetch() (Doc, error) {
@@ -69,97 +61,7 @@ func (db *Duckduckbot) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. creationTime may be absent, so it is optional.
 func ProcessData(data []byte) (Doc, error) {
-	var (
-		doc    Doc
-		rawDoc RawDoc
-	)
-	err := json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	// creationTime may be absent from the feed, so treat it as optional.
-	if rawDoc.CreationTime != "" {
-		var ct time.Time
-
-		ct, err = time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
-		if err != nil {
-			return Doc{}, err
-		}
-
-		doc.CreationTime = ct
-	}
-
-	return doc, nil
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var (
-		ipv4 []IPv4Entry
-		ipv6 []IPv6Entry
-	)
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{})
 }

--- a/providers/duckduckbot/duckduckbot_test.go
+++ b/providers/duckduckbot/duckduckbot_test.go
@@ -31,8 +31,8 @@ func TestFetch(t *testing.T) {
 	doc, err := ac.Fetch()
 	require.NoError(t, err)
 	require.NotEmpty(t, doc.IPv4Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, duckduckbot.IPv4Entry{netip.MustParsePrefix("104.43.54.127/32")})
-	require.Contains(t, doc.IPv4Prefixes, duckduckbot.IPv4Entry{netip.MustParsePrefix("13.86.35.212/32")})
+	require.Contains(t, doc.IPv4Prefixes, duckduckbot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("104.43.54.127/32")})
+	require.Contains(t, doc.IPv4Prefixes, duckduckbot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("13.86.35.212/32")})
 }
 
 func TestProcessData(t *testing.T) {
@@ -43,6 +43,6 @@ func TestProcessData(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, doc.IPv4Prefixes, 4)
 	require.Empty(t, doc.IPv6Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, duckduckbot.IPv4Entry{netip.MustParsePrefix("128.203.132.152/32")})
+	require.Contains(t, doc.IPv4Prefixes, duckduckbot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("128.203.132.152/32")})
 	require.Equal(t, time.Date(2026, time.July, 3, 15, 15, 37, 0, time.UTC), doc.CreationTime)
 }

--- a/providers/googlebot/googlebot.go
+++ b/providers/googlebot/googlebot.go
@@ -1,23 +1,40 @@
 package googlebot
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
 const (
-	ShortName                = "googlebot"
-	FullName                 = "Google Crawler Bots"
-	HostType                 = "crawlers"
-	SourceURL                = "https://developers.google.com/search/docs/crawling-indexing/verifying-googlebot"
-	DownloadURL              = "https://developers.google.com/static/crawling/ipranges/common-crawlers.json"
-	downloadedFileTimeFormat = "2006-01-02T15:04:05.999999"
+	ShortName   = "googlebot"
+	FullName    = "Google Crawler Bots"
+	HostType    = "crawlers"
+	SourceURL   = "https://developers.google.com/search/docs/crawling-indexing/verifying-googlebot"
+	DownloadURL = "https://developers.google.com/static/crawling/ipranges/common-crawlers.json"
 )
+
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Googlebot struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
+}
 
 func New() Googlebot {
 	return Googlebot{
@@ -27,37 +44,12 @@ func New() Googlebot {
 	}
 }
 
-type Googlebot struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (gc *Googlebot) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
 	if gc.DownloadURL == "" {
 		gc.DownloadURL = DownloadURL
 	}
-	data, headers, status, err = web.Request(
-		gc.Client,
-		gc.DownloadURL,
-		http.MethodGet,
-		nil,
-		nil,
-		gc.Timeout,
-	)
-	return data, headers, status, err
+
+	return web.Request(gc.Client, gc.DownloadURL, http.MethodGet, nil, nil, gc.Timeout)
 }
 
 func (gc *Googlebot) Fetch() (Doc, error) {
@@ -69,92 +61,8 @@ func (gc *Googlebot) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. Google always publishes creationTime, so its
+// absence is an error.
 func ProcessData(data []byte) (Doc, error) {
-	var (
-		doc    Doc
-		rawDoc RawDoc
-	)
-	err := json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	ct, err := time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.CreationTime = ct
-
-	return doc, nil
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var (
-		ipv4 []IPv4Entry
-		ipv6 []IPv6Entry
-	)
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{RequireCreationTime: true})
 }

--- a/providers/googlebot/googlebot_test.go
+++ b/providers/googlebot/googlebot_test.go
@@ -29,7 +29,7 @@ func TestFetch(t *testing.T) {
 	doc, err := ac.Fetch()
 	require.NoError(t, err)
 	require.NotEmpty(t, doc.IPv4Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, googlebot.IPv4Entry{netip.MustParsePrefix("66.249.79.64/27")})
+	require.Contains(t, doc.IPv4Prefixes, googlebot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("66.249.79.64/27")})
 	require.NotEmpty(t, doc.IPv6Prefixes)
-	require.Contains(t, doc.IPv6Prefixes, googlebot.IPv6Entry{netip.MustParsePrefix("2001:4860:4801:11::/64")})
+	require.Contains(t, doc.IPv6Prefixes, googlebot.IPv6Entry{IPv6Prefix: netip.MustParsePrefix("2001:4860:4801:11::/64")})
 }

--- a/providers/googlesc/googlesc.go
+++ b/providers/googlesc/googlesc.go
@@ -1,23 +1,40 @@
 package googlesc
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
 const (
-	ShortName                = "googlesc"
-	FullName                 = "Google Special Crawlers"
-	HostType                 = "crawlers"
-	SourceURL                = "https://developers.google.com/search/docs/crawling-indexing/verifying-googlebot"
-	DownloadURL              = "https://developers.google.com/static/crawling/ipranges/special-crawlers.json"
-	downloadedFileTimeFormat = "2006-01-02T15:04:05.999999"
+	ShortName   = "googlesc"
+	FullName    = "Google Special Crawlers"
+	HostType    = "crawlers"
+	SourceURL   = "https://developers.google.com/search/docs/crawling-indexing/verifying-googlebot"
+	DownloadURL = "https://developers.google.com/static/crawling/ipranges/special-crawlers.json"
 )
+
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Googlesc struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
+}
 
 func New() Googlesc {
 	return Googlesc{
@@ -27,37 +44,12 @@ func New() Googlesc {
 	}
 }
 
-type Googlesc struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (gs *Googlesc) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
 	if gs.DownloadURL == "" {
 		gs.DownloadURL = DownloadURL
 	}
-	data, headers, status, err = web.Request(
-		gs.Client,
-		gs.DownloadURL,
-		http.MethodGet,
-		nil,
-		nil,
-		gs.Timeout,
-	)
-	return data, headers, status, err
+
+	return web.Request(gs.Client, gs.DownloadURL, http.MethodGet, nil, nil, gs.Timeout)
 }
 
 func (gs *Googlesc) Fetch() (Doc, error) {
@@ -69,92 +61,8 @@ func (gs *Googlesc) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. Google always publishes creationTime, so its
+// absence is an error.
 func ProcessData(data []byte) (Doc, error) {
-	var (
-		doc    Doc
-		rawDoc RawDoc
-	)
-	err := json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	ct, err := time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.CreationTime = ct
-
-	return doc, nil
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var (
-		ipv4 []IPv4Entry
-		ipv6 []IPv6Entry
-	)
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{RequireCreationTime: true})
 }

--- a/providers/googleutf/googleutf.go
+++ b/providers/googleutf/googleutf.go
@@ -1,23 +1,40 @@
 package googleutf
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
 const (
-	ShortName                = "googleutf"
-	FullName                 = "Google User-Triggered Fetchers"
-	HostType                 = "crawlers"
-	SourceURL                = "https://developers.google.com/search/docs/crawling-indexing/verifying-googlebot"
-	DownloadURL              = "https://developers.google.com/static/crawling/ipranges/user-triggered-fetchers.json"
-	downloadedFileTimeFormat = "2006-01-02T15:04:05.999999"
+	ShortName   = "googleutf"
+	FullName    = "Google User-Triggered Fetchers"
+	HostType    = "crawlers"
+	SourceURL   = "https://developers.google.com/search/docs/crawling-indexing/verifying-googlebot"
+	DownloadURL = "https://developers.google.com/static/crawling/ipranges/user-triggered-fetchers.json"
 )
+
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Googleutf struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
+}
 
 func New() Googleutf {
 	return Googleutf{
@@ -27,22 +44,11 @@ func New() Googleutf {
 	}
 }
 
-type Googleutf struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (gu *Googleutf) FetchData() ([]byte, http.Header, int, error) {
 	if gu.DownloadURL == "" {
 		gu.DownloadURL = DownloadURL
 	}
+
 	return web.Request(gu.Client, gu.DownloadURL, http.MethodGet, nil, nil, gu.Timeout)
 }
 
@@ -55,88 +61,8 @@ func (gu *Googleutf) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. Google always publishes creationTime, so its
+// absence is an error.
 func ProcessData(data []byte) (Doc, error) {
-	var rawDoc RawDoc
-	if err := json.Unmarshal(data, &rawDoc); err != nil {
-		return Doc{}, err
-	}
-
-	ipv4, ipv6, err := castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	ct, err := time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	return Doc{
-		CreationTime: ct,
-		IPv4Prefixes: ipv4,
-		IPv6Prefixes: ipv6,
-	}, nil
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var ipv4 []IPv4Entry
-	var ipv6 []IPv6Entry
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{RequireCreationTime: true})
 }

--- a/providers/googleutf/googleutf_test.go
+++ b/providers/googleutf/googleutf_test.go
@@ -29,7 +29,7 @@ func TestFetch(t *testing.T) {
 	doc, err := sc.Fetch()
 	require.NoError(t, err)
 	require.NotEmpty(t, doc.IPv4Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, googleutf.IPv4Entry{netip.MustParsePrefix("35.187.132.96/27")})
+	require.Contains(t, doc.IPv4Prefixes, googleutf.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("35.187.132.96/27")})
 	require.NotEmpty(t, doc.IPv6Prefixes)
-	require.Contains(t, doc.IPv6Prefixes, googleutf.IPv6Entry{netip.MustParsePrefix("2404:f340:4010:4000::/64")})
+	require.Contains(t, doc.IPv6Prefixes, googleutf.IPv6Entry{IPv6Prefix: netip.MustParsePrefix("2404:f340:4010:4000::/64")})
 }

--- a/providers/perplexitybot/perplexitybot.go
+++ b/providers/perplexitybot/perplexitybot.go
@@ -1,23 +1,40 @@
 package perplexitybot
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ip-fetcher/internal/botprefix"
 	"github.com/jonhadfield/ip-fetcher/internal/web"
 )
 
 const (
-	ShortName                = "perplexitybot"
-	FullName                 = "PerplexityBot"
-	HostType                 = "crawlers"
-	SourceURL                = "https://www.perplexity.com/perplexitybot.json"
-	DownloadURL              = "https://www.perplexity.com/perplexitybot.json"
-	downloadedFileTimeFormat = "2006-01-02T15:04:05.999999"
+	ShortName   = "perplexitybot"
+	FullName    = "PerplexityBot"
+	HostType    = "crawlers"
+	SourceURL   = "https://www.perplexity.com/perplexitybot.json"
+	DownloadURL = "https://www.perplexity.com/perplexitybot.json"
 )
+
+// The document format is shared with the other crawler providers, so the
+// parsing lives in internal/botprefix. These are aliases, not new types, so
+// this package's API is unchanged.
+
+type (
+	Doc          = botprefix.Doc
+	RawDoc       = botprefix.RawDoc
+	IPv4Entry    = botprefix.IPv4Entry
+	IPv6Entry    = botprefix.IPv6Entry
+	RawIPv4Entry = botprefix.RawIPv4Entry
+	RawIPv6Entry = botprefix.RawIPv6Entry
+)
+
+type Perplexitybot struct {
+	Client      *retryablehttp.Client
+	DownloadURL string
+	Timeout     time.Duration
+}
 
 func New() Perplexitybot {
 	return Perplexitybot{
@@ -27,37 +44,12 @@ func New() Perplexitybot {
 	}
 }
 
-type Perplexitybot struct {
-	Client      *retryablehttp.Client
-	DownloadURL string
-	Timeout     time.Duration
-}
-
-type RawDoc struct {
-	CreationTime  string            `json:"creationTime"`
-	LastRequested time.Time         `json:"-" yaml:"-"`
-	Entries       []json.RawMessage `json:"prefixes"`
-}
-
 func (pb *Perplexitybot) FetchData() ([]byte, http.Header, int, error) {
-	var (
-		data    []byte
-		headers http.Header
-		status  int
-		err     error
-	)
 	if pb.DownloadURL == "" {
 		pb.DownloadURL = DownloadURL
 	}
-	data, headers, status, err = web.Request(
-		pb.Client,
-		pb.DownloadURL,
-		http.MethodGet,
-		nil,
-		nil,
-		pb.Timeout,
-	)
-	return data, headers, status, err
+
+	return web.Request(pb.Client, pb.DownloadURL, http.MethodGet, nil, nil, pb.Timeout)
 }
 
 func (pb *Perplexitybot) Fetch() (Doc, error) {
@@ -69,97 +61,7 @@ func (pb *Perplexitybot) Fetch() (Doc, error) {
 	return ProcessData(data)
 }
 
+// ProcessData parses the feed. creationTime may be absent, so it is optional.
 func ProcessData(data []byte) (Doc, error) {
-	var (
-		doc    Doc
-		rawDoc RawDoc
-	)
-	err := json.Unmarshal(data, &rawDoc)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	doc.IPv4Prefixes, doc.IPv6Prefixes, err = castEntries(rawDoc.Entries)
-	if err != nil {
-		return Doc{}, err
-	}
-
-	// creationTime may be absent from the feed, so treat it as optional.
-	if rawDoc.CreationTime != "" {
-		var ct time.Time
-
-		ct, err = time.Parse(downloadedFileTimeFormat, rawDoc.CreationTime)
-		if err != nil {
-			return Doc{}, err
-		}
-
-		doc.CreationTime = ct
-	}
-
-	return doc, nil
-}
-
-func castEntries(prefixes []json.RawMessage) ([]IPv4Entry, []IPv6Entry, error) {
-	var (
-		ipv4 []IPv4Entry
-		ipv6 []IPv6Entry
-	)
-	for _, pr := range prefixes {
-		var ipv4entry RawIPv4Entry
-
-		var ipv6entry RawIPv6Entry
-
-		// try 4
-		if err := json.Unmarshal(pr, &ipv4entry); err == nil {
-			ipv4Prefix, parseError := netip.ParsePrefix(ipv4entry.IPv4Prefix)
-			if parseError == nil {
-				ipv4 = append(ipv4, IPv4Entry{
-					IPv4Prefix: ipv4Prefix,
-				})
-
-				continue
-			}
-		}
-
-		// try 6
-		ipv6Err := json.Unmarshal(pr, &ipv6entry)
-		if ipv6Err == nil {
-			ipv6Prefix, parseError := netip.ParsePrefix(ipv6entry.IPv6Prefix)
-			if parseError != nil {
-				return ipv4, ipv6, parseError
-			}
-
-			ipv6 = append(ipv6, IPv6Entry{
-				IPv6Prefix: ipv6Prefix,
-			})
-
-			continue
-		}
-
-		return ipv4, ipv6, ipv6Err
-	}
-
-	return ipv4, ipv6, nil
-}
-
-type RawIPv4Entry struct {
-	IPv4Prefix string `json:"ipv4Prefix"`
-}
-
-type RawIPv6Entry struct {
-	IPv6Prefix string `json:"ipv6Prefix"`
-}
-
-type IPv4Entry struct {
-	IPv4Prefix netip.Prefix `json:"ipv4Prefix"`
-}
-
-type IPv6Entry struct {
-	IPv6Prefix netip.Prefix `json:"ipv6Prefix"`
-}
-
-type Doc struct {
-	CreationTime time.Time   `json:"creationTime" yaml:"creationTime"`
-	IPv4Prefixes []IPv4Entry `json:"ipv4Prefixes" yaml:"ipv4Prefixes"`
-	IPv6Prefixes []IPv6Entry `json:"ipv6Prefixes" yaml:"ipv6Prefixes"`
+	return botprefix.Parse(data, botprefix.Options{})
 }

--- a/providers/perplexitybot/perplexitybot_test.go
+++ b/providers/perplexitybot/perplexitybot_test.go
@@ -30,8 +30,8 @@ func TestFetch(t *testing.T) {
 	doc, err := ac.Fetch()
 	require.NoError(t, err)
 	require.NotEmpty(t, doc.IPv4Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, perplexitybot.IPv4Entry{netip.MustParsePrefix("107.20.236.150/32")})
-	require.Contains(t, doc.IPv4Prefixes, perplexitybot.IPv4Entry{netip.MustParsePrefix("18.97.9.96/29")})
+	require.Contains(t, doc.IPv4Prefixes, perplexitybot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("107.20.236.150/32")})
+	require.Contains(t, doc.IPv4Prefixes, perplexitybot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("18.97.9.96/29")})
 }
 
 func TestProcessData(t *testing.T) {
@@ -42,6 +42,6 @@ func TestProcessData(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, doc.IPv4Prefixes, 4)
 	require.Empty(t, doc.IPv6Prefixes)
-	require.Contains(t, doc.IPv4Prefixes, perplexitybot.IPv4Entry{netip.MustParsePrefix("3.224.62.45/32")})
+	require.Contains(t, doc.IPv4Prefixes, perplexitybot.IPv4Entry{IPv4Prefix: netip.MustParsePrefix("3.224.62.45/32")})
 	require.Equal(t, 2025, doc.CreationTime.Year())
 }


### PR DESCRIPTION
The eight bot providers all consume the same document - a `creationTime` and
a `prefixes` array whose entries carry either `ipv4Prefix` or `ipv6Prefix`.
Sonar had them at 50-60% duplication each (#125).

```
before   8 x ~165            = ~1,320 lines
after    8 x 67  + 143       =    679 lines
```

Their type declarations were **byte identical** across all eight, and the
`downloadedFileTimeFormat` constant was the same in every one.

### The one real difference, preserved

They diverge in exactly one respect, and flattening it would have been the
easy mistake:

| providers | creationTime |
| --- | --- |
| googlebot, googlesc, googleutf | **required** - absence is an error |
| ahrefs, applebot, duckduckbot, perplexitybot | optional, single format |
| anthropic | optional, RFC3339 **or** fractional seconds |

Collapsing these into one lenient path would silently stop Google's feeds
complaining about a malformed document. `botprefix.Options` carries the
policy per provider instead.

### Verified, not assumed

**API unchanged.** Exported symbol sets extracted with `go doc -all` on this
branch and on `main` and diffed: identical for all eight. `Doc`, `RawDoc`,
`IPv4Entry`, `IPv6Entry`, `RawIPv4Entry` and `RawIPv6Entry` are aliases, so
they are the same types consumers already have.

**Behaviour unchanged.** A probe ran every provider's `ProcessData` over
three documents - no creationTime, RFC3339, fractional seconds - on `main`
and on this branch. The 8x3 matrix matches exactly, including googlebot
rejecting a document that ahrefs accepts.

**The shared package is tested.** 97.5% coverage, with each of the three
creationTime policies pinned by its own case. In #126 the equivalent
extraction left the shared code untested and coverage collapsed, because
`go test` only instruments the package under test; that lesson is applied
here up front.

### One consumer visible consequence

`go vet` flags unkeyed composite literals for types imported from another
package, and the entry types now come from `internal/botprefix`. The tests
in this repo are updated to use keyed fields, which is better practice
anyway, but anyone writing `ahrefs.IPv4Entry{prefix}` without the field name
will see a vet warning. It still compiles.

### Testing

Full suite passes (56 packages, 0 failures), `go vet` and
`golangci-lint run ./...` clean.