### PR TITLE
run goreleaser on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,27 @@ jobs:
           ${{ github.repository }}:${{ env.TAG }}
           ghcr.io/${{ github.repository }}:latest
           ghcr.io/${{ github.repository }}:${{ env.TAG }}
+
+  goreleaser:
+    runs-on: ubuntu-latest
+    name: GoReleaser
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0  # goreleaser needs the full history for the changelog
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.25'
+
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: '~> v2'
+          args: release --clean -f goreleaser.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: ip-fetcher
 
 env:
@@ -9,64 +11,9 @@ before:
   hooks:
     - make clean
     - go mod tidy
+
 builds:
-  -
-    id: macos-ip-fetcher
-    main: ./cmd/ip-fetcher/
-    binary: ip-fetcher
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    flags:
-      - -trimpath
-    ldflags:
-      - "-s -w -X main.version={{ .Version }} -X main.sha={{ .ShortCommit }} -X main.buildDate={{ .Date }} -X main.tag={{ .Tag }}"
-    hooks:
-      post:
-        - |
-          sh -c '
-          cat > /tmp/ip-fetcher_gon_arm64.hcl << EOF
-          source = ["./dist/macos-ip-fetcher_darwin_arm64/ip-fetcher"]
-          bundle_id = "uk.co.lessknown.ip-fetcher"
-          apple_id {
-            username = "jon@lessknown.co.uk"
-            password = "@env:AC_PASSWORD"
-          }
-          sign {
-            application_identity = "Developer ID Application: Jonathan Hadfield (VBZY8FBYR5)"
-          }
-          zip {
-            output_path = "./dist/ip-fetcher_darwin_arm64.zip"
-          }
-          EOF
-          gon /tmp/ip-fetcher_gon_arm64.hcl
-          echo $?
-          '
-          echo $?
-        - |
-          sh -c '
-          cat > /tmp/ip-fetcher_gon_amd64.hcl << EOF
-          source = ["./dist/macos-ip-fetcher_darwin_amd64_v1/ip-fetcher"]
-          bundle_id = "uk.co.lessknown.ip-fetcher"
-          apple_id {
-            username = "jon@lessknown.co.uk"
-            password = "@env:AC_PASSWORD"
-          }
-          sign {
-            application_identity = "Developer ID Application: Jonathan Hadfield (VBZY8FBYR5)"
-          }
-          zip {
-            output_path = "./dist/ip-fetcher_darwin_amd64_v1.zip"
-          }
-          EOF
-          echo $?
-          gon /tmp/ip-fetcher_gon_amd64.hcl
-          echo $?
-          '
-  -
-    id: ip-fetcher
+  - id: ip-fetcher
     main: ./cmd/ip-fetcher/
     binary: ip-fetcher
     env:
@@ -75,10 +22,17 @@ builds:
       - linux
       - windows
       - freebsd
+      - darwin
     goarch:
       - amd64
       - arm
       - arm64
+    ignore:
+      # 32 bit arm is not a darwin or windows target
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
     flags:
       - -trimpath
     ldflags:
@@ -86,12 +40,14 @@ builds:
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    builds:
+    ids:
       - ip-fetcher
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - none*
 
@@ -101,14 +57,12 @@ release:
     name: ip-fetcher
   prerelease: auto
   name_template: '{{ .Tag }}'
-  extra_files:
-    - glob: ./dist/ip-fetcher_darwin*.zip
 
 announce:
   skip: true
 
 snapshot:
-  name_template: "{{ .Tag }}-devel"
+  version_template: "{{ .Tag }}-devel"
 
 changelog:
   sort: asc


### PR DESCRIPTION
The workflow is called `goreleaser` but never ran goreleaser - it only built
and pushed docker images. That is why no binaries or release notes have been
published since **0.0.10, in March 2024**, despite 25 tags existing.

```
tags:     v0.0.11 … v0.0.22   docker images only
releases: 0.0.10 and older    last real goreleaser run
```

Anyone following the README or expecting a downloadable binary has had
nothing new for over two years.

### The config had also stopped validating

Wiring the existing file in would simply have failed. `goreleaser check`
against v2.17.1:

```
only version: 2 configuration files are supported, yours is version: 0
DEPRECATED: snapshot.name_template
DEPRECATED: archives.format
DEPRECATED: archives.format_overrides.format
DEPRECATED: archives.builds
```

It is a v1 era config, which fits the timeline - the last release predates
the goreleaser v2 migration. Migrated to `version: 2` with each deprecated
property updated.

### macOS binaries are now unsigned

The old config shelled out to `gon` for notarisation, which needs an Apple
ID, a Developer ID certificate in a keychain and a mac. None of that exists
on `ubuntu-latest`, and `release.extra_files` globbed the zips those hooks
produced, so the release step would have failed too.

darwin now builds alongside the other platforms and ships **unsigned**.
Gatekeeper will warn, where 0.0.10 and earlier did not. The trade is against
shipping nothing at all, which is the status quo. Signing properly would
need a `macos-latest` runner with the certificate and `AC_PASSWORD` as
repository secrets - a separate change, and one that puts a Developer ID
cert in CI.

### Verified before pushing

- `goreleaser check` passes on the migrated config; the committed one fails.
- A full snapshot build produced **all ten targets**:
  darwin, freebsd, linux, windows across amd64, arm and arm64.
- One binary was executed to confirm the version ldflags still resolve:
  `ip-fetcher version [v0.0.22-5347da3] 2026-08-25T15:34:17Z UTC`

The `goreleaser-action` is pinned to a commit sha with its version as a
trailing comment, consistent with #122.

### After merging

`v0.0.22` already points at `main`'s tip, so re-running the release workflow
against that tag would backfill a proper release - binaries, checksums and
notes - for the work merged this week. Deleting and re-pushing the tag, or
dispatching the workflow manually, both do it.